### PR TITLE
Add workspace drift detection command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ hcpt
 ├── project list      # Organization 内の Project 一覧を取得
 ├── workspace list    # Organization 内の Workspace 一覧を取得
 ├── workspace show    # 特定の Workspace の詳細情報を表示
+├── workspace drift   # ドリフト検出状態を表示（単一 or --all）
 ├── run list          # Workspace の Run 履歴を表示
 ├── run show          # Run の詳細情報を表示
 ├── variable list     # Workspace の変数一覧を表示

--- a/README.ja.md
+++ b/README.ja.md
@@ -78,6 +78,12 @@ hcpt ws list --org my-org
 
 # Workspace 詳細
 hcpt workspace show my-workspace --org my-org
+
+# ドリフト検出状態を表示
+hcpt workspace drift my-workspace --org my-org
+
+# 全ワークスペースのドリフト状態を表示
+hcpt workspace drift --all --org my-org
 ```
 
 ### Run

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ hcpt ws list --org my-org
 
 # Show workspace details
 hcpt workspace show my-workspace --org my-org
+
+# Show drift detection status for a workspace
+hcpt workspace drift my-workspace --org my-org
+
+# Show drift status for all workspaces
+hcpt workspace drift --all --org my-org
 ```
 
 ### Runs

--- a/internal/client/assessment_test.go
+++ b/internal/client/assessment_test.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseAssessmentResponse_Drifted(t *testing.T) {
+	body := []byte(`{
+		"data": {
+			"id": "asmnt-abc123",
+			"type": "assessment-results",
+			"attributes": {
+				"drifted": true,
+				"succeeded": true,
+				"resources-drifted": 3,
+				"resources-undrifted": 12,
+				"created-at": "2025-01-20T10:30:00.000Z"
+			}
+		}
+	}`)
+
+	result, err := parseAssessmentResponse(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Drifted {
+		t.Error("expected Drifted to be true")
+	}
+	if !result.Succeeded {
+		t.Error("expected Succeeded to be true")
+	}
+	if result.ResourcesDrifted != 3 {
+		t.Errorf("expected ResourcesDrifted=3, got %d", result.ResourcesDrifted)
+	}
+	if result.ResourcesUndrifted != 12 {
+		t.Errorf("expected ResourcesUndrifted=12, got %d", result.ResourcesUndrifted)
+	}
+	if result.CreatedAt != "2025-01-20T10:30:00.000Z" {
+		t.Errorf("expected CreatedAt=%q, got %q", "2025-01-20T10:30:00.000Z", result.CreatedAt)
+	}
+}
+
+func TestParseAssessmentResponse_NoDrift(t *testing.T) {
+	body := []byte(`{
+		"data": {
+			"id": "asmnt-def456",
+			"type": "assessment-results",
+			"attributes": {
+				"drifted": false,
+				"succeeded": true,
+				"resources-drifted": 0,
+				"resources-undrifted": 15,
+				"created-at": "2025-01-20T10:30:00.000Z"
+			}
+		}
+	}`)
+
+	result, err := parseAssessmentResponse(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Drifted {
+		t.Error("expected Drifted to be false")
+	}
+	if result.ResourcesDrifted != 0 {
+		t.Errorf("expected ResourcesDrifted=0, got %d", result.ResourcesDrifted)
+	}
+	if result.ResourcesUndrifted != 15 {
+		t.Errorf("expected ResourcesUndrifted=15, got %d", result.ResourcesUndrifted)
+	}
+}
+
+func TestParseAssessmentResponse_InvalidJSON(t *testing.T) {
+	body := []byte(`invalid json`)
+
+	_, err := parseAssessmentResponse(body)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse") {
+		t.Errorf("expected 'failed to parse' error, got: %v", err)
+	}
+}
+
+func TestParseAssessmentResponse_EmptyBody(t *testing.T) {
+	body := []byte(`{}`)
+
+	result, err := parseAssessmentResponse(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Drifted {
+		t.Error("expected Drifted to be false for empty response")
+	}
+	if result.ResourcesDrifted != 0 {
+		t.Errorf("expected ResourcesDrifted=0, got %d", result.ResourcesDrifted)
+	}
+}

--- a/internal/cmd/workspace/drift.go
+++ b/internal/cmd/workspace/drift.go
@@ -1,0 +1,212 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/nnstt1/hcpt/internal/client"
+	"github.com/nnstt1/hcpt/internal/output"
+)
+
+type wsDriftService interface {
+	client.WorkspaceService
+	client.AssessmentService
+}
+
+type wsDriftClientFactory func() (wsDriftService, error)
+
+func defaultWSDriftClientFactory() (wsDriftService, error) {
+	return client.NewClientWrapper()
+}
+
+func newCmdWorkspaceDrift() *cobra.Command {
+	return newCmdWorkspaceDriftWith(defaultWSDriftClientFactory)
+}
+
+func newCmdWorkspaceDriftWith(clientFn wsDriftClientFactory) *cobra.Command {
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:   "drift [name]",
+		Short: "Show drift detection status for workspaces",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org := viper.GetString("org")
+			if org == "" {
+				return fmt.Errorf("organization is required: use --org flag, TFE_ORG env, or set 'org' in config file")
+			}
+
+			svc, err := clientFn()
+			if err != nil {
+				return err
+			}
+
+			if all {
+				return runWorkspaceDriftAll(svc, org)
+			}
+
+			if len(args) == 0 {
+				return fmt.Errorf("workspace name is required, or use --all flag to list all workspaces")
+			}
+			return runWorkspaceDrift(svc, org, args[0])
+		},
+	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "show drift status for all workspaces")
+
+	return cmd
+}
+
+type driftJSON struct {
+	Workspace          string `json:"workspace"`
+	Assessments        bool   `json:"assessments"`
+	Drifted            *bool  `json:"drifted"`
+	ResourcesDrifted   *int   `json:"resources_drifted"`
+	ResourcesUndrifted *int   `json:"resources_undrifted"`
+	LastAssessment     string `json:"last_assessment"`
+}
+
+func runWorkspaceDrift(svc wsDriftService, org, name string) error {
+	ctx := context.Background()
+	ws, err := svc.ReadWorkspace(ctx, org, name)
+	if err != nil {
+		return fmt.Errorf("failed to read workspace %q: %w", name, err)
+	}
+
+	var result *client.AssessmentResult
+	if ws.AssessmentsEnabled {
+		result, err = svc.ReadCurrentAssessment(ctx, ws.ID)
+		if err != nil {
+			return fmt.Errorf("failed to read assessment for workspace %q: %w", name, err)
+		}
+	}
+
+	if viper.GetBool("json") {
+		return output.PrintJSON(os.Stdout, toDriftJSON(ws, result))
+	}
+
+	pairs := buildDriftKeyValues(ws, result)
+	output.PrintKeyValue(os.Stdout, pairs)
+	return nil
+}
+
+func runWorkspaceDriftAll(svc wsDriftService, org string) error {
+	ctx := context.Background()
+	opts := &tfe.WorkspaceListOptions{
+		ListOptions: tfe.ListOptions{
+			PageSize: 100,
+		},
+	}
+
+	var allWorkspaces []*tfe.Workspace
+	for {
+		wsList, err := svc.ListWorkspaces(ctx, org, opts)
+		if err != nil {
+			return fmt.Errorf("failed to list workspaces: %w", err)
+		}
+		allWorkspaces = append(allWorkspaces, wsList.Items...)
+		if wsList.Pagination == nil || wsList.CurrentPage >= wsList.TotalPages {
+			break
+		}
+		opts.PageNumber = wsList.NextPage
+	}
+
+	type wsResult struct {
+		ws     *tfe.Workspace
+		result *client.AssessmentResult
+	}
+	results := make([]wsResult, 0, len(allWorkspaces))
+
+	for _, ws := range allWorkspaces {
+		var result *client.AssessmentResult
+		if ws.AssessmentsEnabled {
+			var err error
+			result, err = svc.ReadCurrentAssessment(ctx, ws.ID)
+			if err != nil {
+				return fmt.Errorf("failed to read assessment for workspace %q: %w", ws.Name, err)
+			}
+		}
+		results = append(results, wsResult{ws: ws, result: result})
+	}
+
+	if viper.GetBool("json") {
+		items := make([]driftJSON, 0, len(results))
+		for _, r := range results {
+			items = append(items, toDriftJSON(r.ws, r.result))
+		}
+		return output.PrintJSON(os.Stdout, items)
+	}
+
+	headers := []string{"WORKSPACE", "ASSESSMENTS", "DRIFTED", "RESOURCES DRIFTED", "LAST ASSESSMENT"}
+	rows := make([][]string, 0, len(results))
+	for _, r := range results {
+		rows = append(rows, buildDriftRow(r.ws, r.result))
+	}
+
+	output.Print(os.Stdout, headers, rows)
+	return nil
+}
+
+func buildDriftKeyValues(ws *tfe.Workspace, result *client.AssessmentResult) []output.KeyValue {
+	pairs := []output.KeyValue{
+		{Key: "Workspace", Value: ws.Name},
+		{Key: "Assessments", Value: strconv.FormatBool(ws.AssessmentsEnabled)},
+	}
+
+	if result != nil {
+		pairs = append(pairs,
+			output.KeyValue{Key: "Drifted", Value: strconv.FormatBool(result.Drifted)},
+			output.KeyValue{Key: "Resources Drifted", Value: strconv.Itoa(result.ResourcesDrifted)},
+			output.KeyValue{Key: "Resources Undrifted", Value: strconv.Itoa(result.ResourcesUndrifted)},
+			output.KeyValue{Key: "Last Assessment", Value: result.CreatedAt},
+		)
+	} else {
+		pairs = append(pairs,
+			output.KeyValue{Key: "Drifted", Value: "-"},
+			output.KeyValue{Key: "Resources Drifted", Value: "-"},
+			output.KeyValue{Key: "Resources Undrifted", Value: "-"},
+			output.KeyValue{Key: "Last Assessment", Value: "-"},
+		)
+	}
+
+	return pairs
+}
+
+func buildDriftRow(ws *tfe.Workspace, result *client.AssessmentResult) []string {
+	if result != nil {
+		return []string{
+			ws.Name,
+			strconv.FormatBool(ws.AssessmentsEnabled),
+			strconv.FormatBool(result.Drifted),
+			strconv.Itoa(result.ResourcesDrifted),
+			result.CreatedAt,
+		}
+	}
+	return []string{
+		ws.Name,
+		strconv.FormatBool(ws.AssessmentsEnabled),
+		"-",
+		"-",
+		"-",
+	}
+}
+
+func toDriftJSON(ws *tfe.Workspace, result *client.AssessmentResult) driftJSON {
+	d := driftJSON{
+		Workspace:   ws.Name,
+		Assessments: ws.AssessmentsEnabled,
+	}
+	if result != nil {
+		d.Drifted = &result.Drifted
+		d.ResourcesDrifted = &result.ResourcesDrifted
+		d.ResourcesUndrifted = &result.ResourcesUndrifted
+		d.LastAssessment = result.CreatedAt
+	}
+	return d
+}

--- a/internal/cmd/workspace/drift_test.go
+++ b/internal/cmd/workspace/drift_test.go
@@ -1,0 +1,353 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/spf13/viper"
+
+	"github.com/nnstt1/hcpt/internal/client"
+)
+
+type mockWSDriftService struct {
+	mockWSService
+	assessments map[string]*client.AssessmentResult
+	assessErr   error
+}
+
+func (m *mockWSDriftService) ReadCurrentAssessment(_ context.Context, workspaceID string) (*client.AssessmentResult, error) {
+	if m.assessErr != nil {
+		return nil, m.assessErr
+	}
+	if m.assessments != nil {
+		return m.assessments[workspaceID], nil
+	}
+	return nil, nil
+}
+
+func TestWorkspaceDrift_Single_Table(t *testing.T) {
+	viper.Reset()
+	viper.Set("json", false)
+	viper.Set("org", "test-org")
+
+	mock := &mockWSDriftService{
+		mockWSService: mockWSService{
+			workspace: &tfe.Workspace{
+				Name:               "my-workspace",
+				ID:                 "ws-abc123",
+				AssessmentsEnabled: true,
+			},
+		},
+		assessments: map[string]*client.AssessmentResult{
+			"ws-abc123": {
+				Drifted:            true,
+				Succeeded:          true,
+				ResourcesDrifted:   3,
+				ResourcesUndrifted: 12,
+				CreatedAt:          "2025-01-20T10:30:00.000Z",
+			},
+		},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runWorkspaceDrift(mock, "test-org", "my-workspace")
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	for _, want := range []string{"Workspace:", "my-workspace", "Assessments:", "true", "Drifted:", "true", "Resources Drifted:", "3", "Resources Undrifted:", "12", "Last Assessment:", "2025-01-20T10:30:00.000Z"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestWorkspaceDrift_Single_JSON(t *testing.T) {
+	viper.Reset()
+	viper.Set("json", true)
+	viper.Set("org", "test-org")
+
+	mock := &mockWSDriftService{
+		mockWSService: mockWSService{
+			workspace: &tfe.Workspace{
+				Name:               "my-workspace",
+				ID:                 "ws-abc123",
+				AssessmentsEnabled: true,
+			},
+		},
+		assessments: map[string]*client.AssessmentResult{
+			"ws-abc123": {
+				Drifted:            true,
+				Succeeded:          true,
+				ResourcesDrifted:   3,
+				ResourcesUndrifted: 12,
+				CreatedAt:          "2025-01-20T10:30:00.000Z",
+			},
+		},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runWorkspaceDrift(mock, "test-org", "my-workspace")
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	for _, want := range []string{`"workspace": "my-workspace"`, `"assessments": true`, `"drifted": true`, `"resources_drifted": 3`, `"resources_undrifted": 12`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in JSON output, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestWorkspaceDrift_All_Table(t *testing.T) {
+	viper.Reset()
+	viper.Set("json", false)
+	viper.Set("org", "test-org")
+
+	mock := &mockWSDriftService{
+		mockWSService: mockWSService{
+			workspaces: []*tfe.Workspace{
+				{Name: "prod-vpc", ID: "ws-001", AssessmentsEnabled: true},
+				{Name: "staging", ID: "ws-002", AssessmentsEnabled: true},
+				{Name: "dev", ID: "ws-003", AssessmentsEnabled: false},
+			},
+		},
+		assessments: map[string]*client.AssessmentResult{
+			"ws-001": {Drifted: true, ResourcesDrifted: 3, CreatedAt: "2025-01-20T10:30:00.000Z"},
+			"ws-002": {Drifted: false, ResourcesDrifted: 0, CreatedAt: "2025-01-20T10:30:00.000Z"},
+		},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runWorkspaceDriftAll(mock, "test-org")
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	for _, want := range []string{"WORKSPACE", "ASSESSMENTS", "DRIFTED", "prod-vpc", "staging", "dev", "true", "false"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, got)
+		}
+	}
+	// dev workspace should show "-" for drifted since assessments are disabled
+	lines := strings.Split(got, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "dev") && !strings.Contains(line, "-") {
+			t.Errorf("expected '-' for dev workspace with disabled assessments, got:\n%s", line)
+		}
+	}
+}
+
+func TestWorkspaceDrift_AssessmentsDisabled(t *testing.T) {
+	viper.Reset()
+	viper.Set("json", false)
+	viper.Set("org", "test-org")
+
+	mock := &mockWSDriftService{
+		mockWSService: mockWSService{
+			workspace: &tfe.Workspace{
+				Name:               "my-workspace",
+				ID:                 "ws-abc123",
+				AssessmentsEnabled: false,
+			},
+		},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runWorkspaceDrift(mock, "test-org", "my-workspace")
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	if !strings.Contains(got, "false") {
+		t.Errorf("expected 'false' for assessments in output, got:\n%s", got)
+	}
+	// Should show "-" for drift fields when assessments are disabled
+	if !strings.Contains(got, "-") {
+		t.Errorf("expected '-' for disabled assessment fields, got:\n%s", got)
+	}
+}
+
+func TestWorkspaceDrift_NoOrg(t *testing.T) {
+	viper.Reset()
+
+	cmd := newCmdWorkspaceDriftWith(func() (wsDriftService, error) {
+		return &mockWSDriftService{}, nil
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"my-workspace"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "organization is required") {
+		t.Errorf("expected 'organization is required' error, got: %v", err)
+	}
+}
+
+func TestWorkspaceDrift_ClientError(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	cmd := newCmdWorkspaceDriftWith(func() (wsDriftService, error) {
+		return nil, fmt.Errorf("token missing")
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"my-workspace"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "token missing") {
+		t.Errorf("expected 'token missing' error, got: %v", err)
+	}
+}
+
+func TestWorkspaceDrift_ReadWorkspaceError(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockWSDriftService{
+		mockWSService: mockWSService{
+			readErr: fmt.Errorf("workspace not found"),
+		},
+	}
+
+	cmd := newCmdWorkspaceDriftWith(func() (wsDriftService, error) {
+		return mock, nil
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"nonexistent"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "workspace not found") {
+		t.Errorf("expected 'workspace not found' error, got: %v", err)
+	}
+}
+
+func TestWorkspaceDrift_AssessmentAPIError(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockWSDriftService{
+		mockWSService: mockWSService{
+			workspace: &tfe.Workspace{
+				Name:               "my-workspace",
+				ID:                 "ws-abc123",
+				AssessmentsEnabled: true,
+			},
+		},
+		assessErr: fmt.Errorf("assessment API error"),
+	}
+
+	cmd := newCmdWorkspaceDriftWith(func() (wsDriftService, error) {
+		return mock, nil
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"my-workspace"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "assessment API error") {
+		t.Errorf("expected 'assessment API error' error, got: %v", err)
+	}
+}
+
+func TestWorkspaceDrift_NoArgsNoAll(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	cmd := newCmdWorkspaceDriftWith(func() (wsDriftService, error) {
+		return &mockWSDriftService{}, nil
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "workspace name is required") {
+		t.Errorf("expected 'workspace name is required' error, got: %v", err)
+	}
+}

--- a/internal/cmd/workspace/workspace.go
+++ b/internal/cmd/workspace/workspace.go
@@ -14,6 +14,7 @@ func NewCmdWorkspace() *cobra.Command {
 
 	cmd.AddCommand(newCmdWorkspaceList())
 	cmd.AddCommand(newCmdWorkspaceShow())
+	cmd.AddCommand(newCmdWorkspaceDrift())
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

- `hcpt workspace drift <name>` で単一ワークスペースのドリフト検出状態をキーバリュー形式で表示
- `hcpt workspace drift --all` で全ワークスペースのドリフト状態をテーブル形式で一覧表示
- HCP Terraform の `/api/v2/workspaces/{id}/current-assessment-result` エンドポイントを raw HTTP で呼び出し（Subscription API と同パターン）
- Assessment が無効/未実行の場合は `-` 表示（エラーにしない）
- `--json` フラグによる JSON 出力対応

## Changes

| File | Type | Description |
|------|------|-------------|
| `internal/client/client.go` | Modified | `AssessmentResult`, `AssessmentService`, `ReadCurrentAssessment()`, `parseAssessmentResponse()` 追加 |
| `internal/client/assessment_test.go` | New | パーサーのユニットテスト (4件) |
| `internal/cmd/workspace/drift.go` | New | drift サブコマンド実装 |
| `internal/cmd/workspace/drift_test.go` | New | drift コマンドのテスト (9件) |
| `internal/cmd/workspace/workspace.go` | Modified | drift コマンド登録 |
| `README.md` / `README.ja.md` | Modified | drift コマンドのドキュメント追加 |
| `CLAUDE.md` | Modified | コマンド体系に workspace drift 追加 |

## Test plan

- [x] `go test ./internal/client/` — assessment パーサーテスト通過
- [x] `go test ./internal/cmd/workspace/` — drift コマンドテスト通過
- [x] `golangci-lint run` — lint 問題なし
- [x] 実環境での動作確認（assessment 有効/無効のワークスペース）

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)