### PR TITLE
Add --version/-v flag to display version information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w
+      - -s -w -X github.com/nnstt1/hcpt/internal/version.Version={{.Version}}
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build test lint clean
 
 build:
-	go build -o hcpt .
+	go build -ldflags "-X github.com/nnstt1/hcpt/internal/version.Version=dev" -o hcpt .
 
 test:
 	go test ./...

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -14,14 +14,16 @@ import (
 	"github.com/nnstt1/hcpt/internal/cmd/run"
 	"github.com/nnstt1/hcpt/internal/cmd/variable"
 	"github.com/nnstt1/hcpt/internal/cmd/workspace"
+	"github.com/nnstt1/hcpt/internal/version"
 )
 
 var cfgFile string
 
 var rootCmd = &cobra.Command{
-	Use:   "hcpt",
-	Short: "CLI tool for HCP Terraform",
-	Long:  "A CLI tool to retrieve HCP Terraform configurations and workspace information.",
+	Use:     "hcpt",
+	Short:   "CLI tool for HCP Terraform",
+	Long:    "A CLI tool to retrieve HCP Terraform configurations and workspace information.",
+	Version: version.Version,
 }
 
 func Execute() error {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is set at build time via -ldflags.
+var Version = "dev"


### PR DESCRIPTION
## Summary

- Add `hcpt --version` / `hcpt -v` to display the current version
- Version is injected at build time via `-ldflags` (`internal/version.Version`)
- GoReleaser injects the release tag version; local `make build` defaults to `dev`

## Changes

| File | Change |
|------|--------|
| `internal/version/version.go` | New: version variable with ldflags injection |
| `internal/cmd/root.go` | Set `rootCmd.Version` from version package |
| `.goreleaser.yml` | Add `-X` ldflags for version injection |
| `Makefile` | Add `-X` ldflags for dev version |

## Test plan

- [x] `make build && ./hcpt --version` outputs `hcpt version dev`
- [x] `./hcpt -v` outputs `hcpt version dev`
- [x] All existing tests pass
- [x] Lint passes

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)