### PR TITLE
Add --workspace flag to run show for latest run retrieval (#19)

### DIFF
--- a/internal/cmd/run/show_test.go
+++ b/internal/cmd/run/show_test.go
@@ -11,17 +11,22 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/spf13/viper"
-
-	"github.com/nnstt1/hcpt/internal/client"
 )
 
 type mockRunShowService struct {
-	run    *tfe.Run
-	runErr error
+	run          *tfe.Run
+	runErr       error
+	workspace    *tfe.Workspace
+	workspaceErr error
+	runList      *tfe.RunList
+	runListErr   error
 }
 
 func (m *mockRunShowService) ListRuns(_ context.Context, _ string, _ *tfe.RunListOptions) (*tfe.RunList, error) {
-	return nil, nil
+	if m.runListErr != nil {
+		return nil, m.runListErr
+	}
+	return m.runList, nil
 }
 
 func (m *mockRunShowService) ReadRun(_ context.Context, _ string) (*tfe.Run, error) {
@@ -29,6 +34,17 @@ func (m *mockRunShowService) ReadRun(_ context.Context, _ string) (*tfe.Run, err
 		return nil, m.runErr
 	}
 	return m.run, nil
+}
+
+func (m *mockRunShowService) ListWorkspaces(_ context.Context, _ string, _ *tfe.WorkspaceListOptions) (*tfe.WorkspaceList, error) {
+	return nil, nil
+}
+
+func (m *mockRunShowService) ReadWorkspace(_ context.Context, _, _ string) (*tfe.Workspace, error) {
+	if m.workspaceErr != nil {
+		return nil, m.workspaceErr
+	}
+	return m.workspace, nil
 }
 
 func TestRunShow_Table(t *testing.T) {
@@ -47,7 +63,7 @@ func TestRunShow_Table(t *testing.T) {
 		},
 	}
 
-	cmd := newCmdRunShowWith(func() (client.RunService, error) {
+	cmd := newCmdRunShowWith(func() (runShowService, error) {
 		return mock, nil
 	})
 
@@ -82,7 +98,7 @@ func TestRunShow_Table_Output(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runRunShow(mock, "run-abc123")
+	err := runRunShow(mock, "run-abc123", "", "")
 
 	_ = w.Close()
 	os.Stdout = oldStdout
@@ -124,7 +140,7 @@ func TestRunShow_Table_WithTimestamps(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runRunShow(mock, "run-abc123")
+	err := runRunShow(mock, "run-abc123", "", "")
 
 	_ = w.Close()
 	os.Stdout = oldStdout
@@ -162,7 +178,7 @@ func TestRunShow_JSON(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runRunShow(mock, "run-abc123")
+	err := runRunShow(mock, "run-abc123", "", "")
 
 	_ = w.Close()
 	os.Stdout = oldStdout
@@ -185,7 +201,7 @@ func TestRunShow_JSON(t *testing.T) {
 func TestRunShow_ClientError(t *testing.T) {
 	viper.Reset()
 
-	cmd := newCmdRunShowWith(func() (client.RunService, error) {
+	cmd := newCmdRunShowWith(func() (runShowService, error) {
 		return nil, fmt.Errorf("token missing")
 	})
 
@@ -212,7 +228,7 @@ func TestRunShow_ReadError(t *testing.T) {
 		runErr: fmt.Errorf("run not found"),
 	}
 
-	cmd := newCmdRunShowWith(func() (client.RunService, error) {
+	cmd := newCmdRunShowWith(func() (runShowService, error) {
 		return mock, nil
 	})
 
@@ -235,7 +251,7 @@ func TestRunShow_ReadError(t *testing.T) {
 func TestRunShow_NoArgs(t *testing.T) {
 	viper.Reset()
 
-	cmd := newCmdRunShowWith(func() (client.RunService, error) {
+	cmd := newCmdRunShowWith(func() (runShowService, error) {
 		return &mockRunShowService{}, nil
 	})
 
@@ -248,5 +264,223 @@ func TestRunShow_NoArgs(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "either run-id or --workspace is required") {
+		t.Errorf("expected 'either run-id or --workspace is required' error, got: %v", err)
+	}
+}
+
+func TestRunShow_WithWorkspace_Table(t *testing.T) {
+	viper.Reset()
+	viper.Set("json", false)
+	viper.Set("org", "test-org")
+
+	mock := &mockRunShowService{
+		workspace: &tfe.Workspace{
+			ID:   "ws-123",
+			Name: "production",
+		},
+		runList: &tfe.RunList{
+			Items: []*tfe.Run{
+				{
+					ID:               "run-latest",
+					Status:           tfe.RunApplied,
+					Message:          "Latest run",
+					TerraformVersion: "1.5.0",
+					HasChanges:       true,
+					IsDestroy:        false,
+					CreatedAt:        time.Date(2024, 3, 16, 10, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runRunShow(mock, "", "test-org", "production")
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	for _, want := range []string{"ID:", "run-latest", "Status:", "applied", "Latest run"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunShow_WithWorkspace_JSON(t *testing.T) {
+	viper.Reset()
+	viper.Set("json", true)
+	viper.Set("org", "test-org")
+
+	mock := &mockRunShowService{
+		workspace: &tfe.Workspace{
+			ID:   "ws-123",
+			Name: "production",
+		},
+		runList: &tfe.RunList{
+			Items: []*tfe.Run{
+				{
+					ID:               "run-latest",
+					Status:           tfe.RunApplied,
+					Message:          "Latest run",
+					TerraformVersion: "1.5.0",
+					HasChanges:       true,
+					IsDestroy:        false,
+					CreatedAt:        time.Date(2024, 3, 16, 10, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runRunShow(mock, "", "test-org", "production")
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	for _, want := range []string{`"id": "run-latest"`, `"status": "applied"`, `"message": "Latest run"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in JSON output, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunShow_WithWorkspace_NoRuns(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockRunShowService{
+		workspace: &tfe.Workspace{
+			ID:   "ws-123",
+			Name: "empty-workspace",
+		},
+		runList: &tfe.RunList{
+			Items: []*tfe.Run{},
+		},
+	}
+
+	cmd := newCmdRunShowWith(func() (runShowService, error) {
+		return mock, nil
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"-w", "empty-workspace"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no runs found for workspace") {
+		t.Errorf("expected 'no runs found' error, got: %v", err)
+	}
+}
+
+func TestRunShow_WithWorkspace_WorkspaceNotFound(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockRunShowService{
+		workspaceErr: fmt.Errorf("workspace not found"),
+	}
+
+	cmd := newCmdRunShowWith(func() (runShowService, error) {
+		return mock, nil
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"-w", "nonexistent"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to read workspace") {
+		t.Errorf("expected 'failed to read workspace' error, got: %v", err)
+	}
+}
+
+func TestRunShow_WithWorkspace_NoOrg(t *testing.T) {
+	viper.Reset()
+
+	cmd := newCmdRunShowWith(func() (runShowService, error) {
+		return &mockRunShowService{}, nil
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"-w", "production"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "organization is required") {
+		t.Errorf("expected 'organization is required' error, got: %v", err)
+	}
+}
+
+func TestRunShow_WithWorkspace_ListRunsError(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockRunShowService{
+		workspace: &tfe.Workspace{
+			ID:   "ws-123",
+			Name: "production",
+		},
+		runListErr: fmt.Errorf("API error"),
+	}
+
+	cmd := newCmdRunShowWith(func() (runShowService, error) {
+		return mock, nil
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"-w", "production"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to list runs") {
+		t.Errorf("expected 'failed to list runs' error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- `hcpt run show` コマンドに `--workspace/-w` フラグを追加し、最新の Run を自動取得できるようにしました
- これにより、ユーザーは run-id を事前に調べる必要なく、ワークスペース名だけで最新の Run 詳細を確認できます

## Changes

- `--workspace/-w` フラグを追加
- run-id 引数を省略可能に変更（`Args: MaximumNArgs(1)`）
- run-id が省略された場合、指定されたワークスペースの最新 Run を取得して表示
- run-id が指定された場合は既存の動作を維持（後方互換性）
- 表示ロジックを `displayRun` 関数に抽出して共通化

## Usage

```bash
# 最新 Run を表示（新機能）
hcpt run show -w production-api

# 特定の Run を表示（既存の動作）
hcpt run show run-abc123
```

## Test Coverage

- 既存テストケースを新しいシグネチャに対応
- 新しいテストケース追加:
  - workspace 指定時のテーブル・JSON 表示
  - workspace に Run が存在しない場合のエラー
  - workspace が存在しない場合のエラー
  - org が指定されていない場合のエラー
  - API エラー時のハンドリング

全 24 テストがパス ✓

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)