### PR TITLE
Use Explorer API for workspace list to improve performance

### DIFF
--- a/internal/client/assessment_test.go
+++ b/internal/client/assessment_test.go
@@ -148,6 +148,11 @@ func TestParseExplorerWorkspacesResponse(t *testing.T) {
 				"type": "workspace-summaries",
 				"attributes": {
 					"workspace-name": "prod-vpc",
+					"external-id": "ws-abc123",
+					"workspace-terraform-version": "1.5.0",
+					"current-run-status": "applied",
+					"project-name": "production",
+					"workspace-updated-at": "2024-03-15T12:00:00Z",
 					"drifted": true,
 					"resources-drifted": 3,
 					"resources-undrifted": 12
@@ -157,6 +162,11 @@ func TestParseExplorerWorkspacesResponse(t *testing.T) {
 				"type": "workspace-summaries",
 				"attributes": {
 					"workspace-name": "staging",
+					"external-id": "ws-def456",
+					"workspace-terraform-version": "1.6.0",
+					"current-run-status": "planned_and_finished",
+					"project-name": "staging",
+					"workspace-updated-at": "2024-03-10T08:00:00Z",
 					"drifted": false,
 					"resources-drifted": 0,
 					"resources-undrifted": 20
@@ -182,6 +192,21 @@ func TestParseExplorerWorkspacesResponse(t *testing.T) {
 	if result.Items[0].WorkspaceName != "prod-vpc" {
 		t.Errorf("expected workspace name 'prod-vpc', got %q", result.Items[0].WorkspaceName)
 	}
+	if result.Items[0].WorkspaceID != "ws-abc123" {
+		t.Errorf("expected WorkspaceID 'ws-abc123', got %q", result.Items[0].WorkspaceID)
+	}
+	if result.Items[0].TerraformVersion != "1.5.0" {
+		t.Errorf("expected TerraformVersion '1.5.0', got %q", result.Items[0].TerraformVersion)
+	}
+	if result.Items[0].CurrentRunStatus != "applied" {
+		t.Errorf("expected CurrentRunStatus 'applied', got %q", result.Items[0].CurrentRunStatus)
+	}
+	if result.Items[0].ProjectName != "production" {
+		t.Errorf("expected ProjectName 'production', got %q", result.Items[0].ProjectName)
+	}
+	if result.Items[0].UpdatedAt != "2024-03-15T12:00:00Z" {
+		t.Errorf("expected UpdatedAt '2024-03-15T12:00:00Z', got %q", result.Items[0].UpdatedAt)
+	}
 	if !result.Items[0].Drifted {
 		t.Error("expected prod-vpc to be drifted")
 	}
@@ -190,6 +215,9 @@ func TestParseExplorerWorkspacesResponse(t *testing.T) {
 	}
 	if result.Items[1].Drifted {
 		t.Error("expected staging to not be drifted")
+	}
+	if result.Items[1].WorkspaceID != "ws-def456" {
+		t.Errorf("expected WorkspaceID 'ws-def456', got %q", result.Items[1].WorkspaceID)
 	}
 	if result.TotalPages != 2 {
 		t.Errorf("expected TotalPages=2, got %d", result.TotalPages)

--- a/internal/cmd/drift/list.go
+++ b/internal/cmd/drift/list.go
@@ -66,7 +66,10 @@ func runDriftList(svc driftListService, org string, all bool) error {
 	var allItems []client.ExplorerWorkspace
 	page := 1
 	for {
-		result, err := svc.ListExplorerWorkspaces(ctx, org, driftedOnly, page)
+		result, err := svc.ListExplorerWorkspaces(ctx, org, client.ExplorerListOptions{
+			DriftedOnly: driftedOnly,
+			Page:        page,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query explorer: %w", err)
 		}

--- a/internal/cmd/drift/list_test.go
+++ b/internal/cmd/drift/list_test.go
@@ -19,8 +19,8 @@ type mockDriftListService struct {
 	lastPage int // track requested page
 }
 
-func (m *mockDriftListService) ListExplorerWorkspaces(_ context.Context, _ string, _ bool, page int) (*client.ExplorerWorkspaceList, error) {
-	m.lastPage = page
+func (m *mockDriftListService) ListExplorerWorkspaces(_ context.Context, _ string, opts client.ExplorerListOptions) (*client.ExplorerWorkspaceList, error) {
+	m.lastPage = opts.Page
 	if m.listErr != nil {
 		return nil, m.listErr
 	}
@@ -246,7 +246,8 @@ type mockDriftListServicePaginated struct {
 	pages map[int][]client.ExplorerWorkspace
 }
 
-func (m *mockDriftListServicePaginated) ListExplorerWorkspaces(_ context.Context, _ string, _ bool, page int) (*client.ExplorerWorkspaceList, error) {
+func (m *mockDriftListServicePaginated) ListExplorerWorkspaces(_ context.Context, _ string, opts client.ExplorerListOptions) (*client.ExplorerWorkspaceList, error) {
+	page := opts.Page
 	items := m.pages[page]
 	totalPages := len(m.pages)
 	nextPage := page + 1

--- a/internal/cmd/workspace/json.go
+++ b/internal/cmd/workspace/json.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
+
+	"github.com/nnstt1/hcpt/internal/client"
 )
 
 type workspaceJSON struct {
@@ -32,6 +34,26 @@ func toWorkspaceJSON(ws *tfe.Workspace) workspaceJSON {
 		WorkingDirectory: ws.WorkingDirectory,
 		ResourceCount:    ws.ResourceCount,
 		CreatedAt:        ws.CreatedAt,
+		UpdatedAt:        ws.UpdatedAt,
+	}
+}
+
+type workspaceListJSON struct {
+	Name             string `json:"name"`
+	ID               string `json:"id"`
+	TerraformVersion string `json:"terraform_version"`
+	CurrentRunStatus string `json:"current_run_status"`
+	ProjectName      string `json:"project_name"`
+	UpdatedAt        string `json:"updated_at"`
+}
+
+func toWorkspaceListJSON(ws client.ExplorerWorkspace) workspaceListJSON {
+	return workspaceListJSON{
+		Name:             ws.WorkspaceName,
+		ID:               ws.WorkspaceID,
+		TerraformVersion: ws.TerraformVersion,
+		CurrentRunStatus: ws.CurrentRunStatus,
+		ProjectName:      ws.ProjectName,
 		UpdatedAt:        ws.UpdatedAt,
 	}
 }

--- a/internal/cmd/workspace/list.go
+++ b/internal/cmd/workspace/list.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -14,9 +12,9 @@ import (
 	"github.com/nnstt1/hcpt/internal/output"
 )
 
-type wsListClientFactory func() (client.WorkspaceService, error)
+type wsListClientFactory func() (client.ExplorerService, error)
 
-func defaultWSListClientFactory() (client.WorkspaceService, error) {
+func defaultWSListClientFactory() (client.ExplorerService, error) {
 	return client.NewClientWrapper()
 }
 
@@ -49,49 +47,44 @@ func newCmdWorkspaceListWith(clientFn wsListClientFactory) *cobra.Command {
 	return cmd
 }
 
-func runWorkspaceList(svc client.WorkspaceService, org, search string) error {
+func runWorkspaceList(svc client.ExplorerService, org, search string) error {
 	ctx := context.Background()
-	opts := &tfe.WorkspaceListOptions{
-		ListOptions: tfe.ListOptions{
-			PageSize: 100,
-		},
-	}
-	if search != "" {
-		opts.Search = search
-	}
 
-	var allItems []*tfe.Workspace
+	var allItems []client.ExplorerWorkspace
+	page := 1
 	for {
-		wsList, err := svc.ListWorkspaces(ctx, org, opts)
+		result, err := svc.ListExplorerWorkspaces(ctx, org, client.ExplorerListOptions{
+			Search: search,
+			Page:   page,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to list workspaces: %w", err)
 		}
-		allItems = append(allItems, wsList.Items...)
-		if wsList.Pagination == nil || wsList.NextPage == 0 {
+		allItems = append(allItems, result.Items...)
+		if page >= result.TotalPages {
 			break
 		}
-		opts.PageNumber = wsList.NextPage
+		page = result.NextPage
 	}
 
 	if viper.GetBool("json") {
-		items := make([]workspaceJSON, 0, len(allItems))
+		items := make([]workspaceListJSON, 0, len(allItems))
 		for _, ws := range allItems {
-			items = append(items, toWorkspaceJSON(ws))
+			items = append(items, toWorkspaceListJSON(ws))
 		}
 		return output.PrintJSON(os.Stdout, items)
 	}
 
-	headers := []string{"NAME", "ID", "EXECUTION MODE", "TERRAFORM VERSION", "LOCKED", "AUTO APPLY", "UPDATED AT"}
+	headers := []string{"NAME", "ID", "PROJECT", "TERRAFORM VERSION", "CURRENT RUN", "UPDATED AT"}
 	rows := make([][]string, 0, len(allItems))
 	for _, ws := range allItems {
 		rows = append(rows, []string{
-			ws.Name,
-			ws.ID,
-			ws.ExecutionMode,
+			ws.WorkspaceName,
+			ws.WorkspaceID,
+			ws.ProjectName,
 			ws.TerraformVersion,
-			strconv.FormatBool(ws.Locked),
-			strconv.FormatBool(ws.AutoApply),
-			ws.UpdatedAt.Format("2006-01-02 15:04:05"),
+			ws.CurrentRunStatus,
+			ws.UpdatedAt,
 		})
 	}
 

--- a/internal/cmd/workspace/show_test.go
+++ b/internal/cmd/workspace/show_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -13,6 +14,29 @@ import (
 
 	"github.com/nnstt1/hcpt/internal/client"
 )
+
+type mockWSService struct {
+	workspaces []*tfe.Workspace
+	workspace  *tfe.Workspace
+	listErr    error
+	readErr    error
+}
+
+func (m *mockWSService) ListWorkspaces(_ context.Context, _ string, _ *tfe.WorkspaceListOptions) (*tfe.WorkspaceList, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return &tfe.WorkspaceList{
+		Items: m.workspaces,
+	}, nil
+}
+
+func (m *mockWSService) ReadWorkspace(_ context.Context, _ string, _ string) (*tfe.Workspace, error) {
+	if m.readErr != nil {
+		return nil, m.readErr
+	}
+	return m.workspace, nil
+}
 
 func TestWorkspaceShow_Table(t *testing.T) {
 	viper.Reset()


### PR DESCRIPTION
## Summary
- Switch `workspace list` backend from Workspaces API to Explorer API for faster, lighter responses
- Update table columns: replace EXECUTION MODE / LOCKED / AUTO APPLY with PROJECT / CURRENT RUN
- Introduce `ExplorerListOptions` struct with search filter support and refactor `ExplorerService` interface
- Add pagination support to `workspace list` via Explorer API

## Test plan
- [x] `go test ./internal/client/ ./internal/cmd/workspace/ ./internal/cmd/drift/` all pass
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `go build -o hcpt .` succeeds
- [x] Manual test: `hcpt workspace list` returns expected columns
- [x] Manual test: `hcpt workspace list --search <name>` filters correctly
- [x] Manual test: `hcpt workspace list --json` returns new JSON schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)