### PR TITLE
Standardize error messages and improve help display behavior

### DIFF
--- a/internal/cmd/config/get.go
+++ b/internal/cmd/config/get.go
@@ -17,7 +17,8 @@ Available keys:
   org       HCP Terraform organization name
   token     API token (masked for security)
   address   HCP Terraform API address`,
-		Args: cobra.ExactArgs(1),
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runConfigGet(args[0])
 		},

--- a/internal/cmd/config/list.go
+++ b/internal/cmd/config/list.go
@@ -18,8 +18,9 @@ type configJSON struct {
 
 func newCmdConfigList() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List all configuration values",
+		Use:          "list",
+		Short:        "List all configuration values",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runConfigList()
 		},

--- a/internal/cmd/config/set.go
+++ b/internal/cmd/config/set.go
@@ -20,7 +20,8 @@ Available keys:
   org       HCP Terraform organization name
   token     API token
   address   HCP Terraform API address`,
-		Args: cobra.ExactArgs(2),
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runConfigSet(args[0], args[1])
 		},

--- a/internal/cmd/drift/list.go
+++ b/internal/cmd/drift/list.go
@@ -31,8 +31,9 @@ func newCmdDriftListWith(clientFn driftListClientFactory) *cobra.Command {
 	var all bool
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List workspaces with drift status",
+		Use:          "list",
+		Short:        "List workspaces with drift status",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org := viper.GetString("org")
 			if org == "" {

--- a/internal/cmd/drift/show.go
+++ b/internal/cmd/drift/show.go
@@ -31,9 +31,10 @@ func newCmdDriftShow() *cobra.Command {
 
 func newCmdDriftShowWith(clientFn driftShowClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show <workspace>",
-		Short: "Show drift detection detail for a workspace",
-		Args:  cobra.ExactArgs(1),
+		Use:          "show <workspace>",
+		Short:        "Show drift detection detail for a workspace",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org := viper.GetString("org")
 			if org == "" {

--- a/internal/cmd/org/list.go
+++ b/internal/cmd/org/list.go
@@ -32,8 +32,9 @@ func newCmdOrgList() *cobra.Command {
 
 func newCmdOrgListWith(clientFn orgListClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List organizations",
+		Use:          "list",
+		Short:        "List organizations",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			svc, err := clientFn()
 			if err != nil {

--- a/internal/cmd/org/show.go
+++ b/internal/cmd/org/show.go
@@ -52,8 +52,9 @@ func newCmdOrgShow() *cobra.Command {
 
 func newCmdOrgShowWith(clientFn orgShowClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show",
-		Short: "Show organization details",
+		Use:          "show",
+		Short:        "Show organization details",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org := viper.GetString("org")
 			if org == "" {

--- a/internal/cmd/project/list.go
+++ b/internal/cmd/project/list.go
@@ -31,8 +31,9 @@ func newCmdProjectList() *cobra.Command {
 
 func newCmdProjectListWith(clientFn projectListClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List projects in an organization",
+		Use:          "list",
+		Short:        "List projects in an organization",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org := viper.GetString("org")
 			if org == "" {

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -54,7 +54,7 @@ func newCmdRunListWith(clientFn runListClientFactory) *cobra.Command {
 				return fmt.Errorf("organization is required: use --org flag, TFE_ORG env, or set 'org' in config file")
 			}
 			if workspaceName == "" {
-				return fmt.Errorf("workspace is required: use --workspace (-w) flag")
+				return fmt.Errorf("workspace is required: use --workspace/-w flag")
 			}
 
 			svc, err := clientFn()

--- a/internal/cmd/run/show.go
+++ b/internal/cmd/run/show.go
@@ -83,7 +83,7 @@ func newCmdRunShowWith(clientFn runShowClientFactory) *cobra.Command {
 			}
 
 			if runID == "" && prNumber == 0 && workspaceName == "" {
-				return fmt.Errorf("either run-id, --pr, or --workspace is required")
+				return fmt.Errorf("either run-id, --pr, or --workspace/-w is required")
 			}
 
 			svc, err := clientFn()
@@ -164,7 +164,7 @@ func runRunShowWithInterval(svc runShowService, runID string, org string, worksp
 			return fmt.Errorf("failed to read run %q: %w", runID, err)
 		}
 	} else {
-		return fmt.Errorf("either run-id or --workspace is required")
+		return fmt.Errorf("either run-id or --workspace/-w is required")
 	}
 
 	// watch モードの場合

--- a/internal/cmd/run/show_test.go
+++ b/internal/cmd/run/show_test.go
@@ -338,8 +338,8 @@ func TestRunShow_NoArgs(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "either run-id, --pr, or --workspace is required") {
-		t.Errorf("expected 'either run-id, --pr, or --workspace is required' error, got: %v", err)
+	if !strings.Contains(err.Error(), "either run-id, --pr, or --workspace/-w is required") {
+		t.Errorf("expected 'either run-id, --pr, or --workspace/-w is required' error, got: %v", err)
 	}
 }
 
@@ -1050,7 +1050,7 @@ func TestRunShow_NoArgsNoPRNoWorkspace(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "either run-id, --pr, or --workspace is required") {
-		t.Errorf("expected 'run-id or --pr or --workspace required' error, got: %v", err)
+	if !strings.Contains(err.Error(), "either run-id, --pr, or --workspace/-w is required") {
+		t.Errorf("expected 'run-id or --pr or --workspace/-w required' error, got: %v", err)
 	}
 }

--- a/internal/cmd/variable/delete.go
+++ b/internal/cmd/variable/delete.go
@@ -33,16 +33,17 @@ func newCmdVariableDeleteWith(clientFn variableDeleteClientFactory) *cobra.Comma
 	)
 
 	cmd := &cobra.Command{
-		Use:   "delete <key>",
-		Short: "Delete a workspace variable",
-		Args:  cobra.ExactArgs(1),
+		Use:          "delete <key>",
+		Short:        "Delete a workspace variable",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org := viper.GetString("org")
 			if org == "" {
 				return fmt.Errorf("organization is required: use --org flag, TFE_ORG env, or set 'org' in config file")
 			}
 			if workspaceName == "" {
-				return fmt.Errorf("workspace is required: use --workspace (-w) flag")
+				return fmt.Errorf("workspace is required: use --workspace/-w flag")
 			}
 
 			cat := tfe.CategoryTerraform

--- a/internal/cmd/variable/list.go
+++ b/internal/cmd/variable/list.go
@@ -41,15 +41,16 @@ func newCmdVariableListWith(clientFn variableListClientFactory) *cobra.Command {
 	var workspaceName string
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List variables for a workspace",
+		Use:          "list",
+		Short:        "List variables for a workspace",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org := viper.GetString("org")
 			if org == "" {
 				return fmt.Errorf("organization is required: use --org flag, TFE_ORG env, or set 'org' in config file")
 			}
 			if workspaceName == "" {
-				return fmt.Errorf("workspace is required: use --workspace (-w) flag")
+				return fmt.Errorf("workspace is required: use --workspace/-w flag")
 			}
 
 			svc, err := clientFn()

--- a/internal/cmd/variable/set.go
+++ b/internal/cmd/variable/set.go
@@ -36,16 +36,17 @@ func newCmdVariableSetWith(clientFn variableSetClientFactory) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "set <key> <value>",
-		Short: "Create or update a workspace variable",
-		Args:  cobra.ExactArgs(2),
+		Use:          "set <key> <value>",
+		Short:        "Create or update a workspace variable",
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org := viper.GetString("org")
 			if org == "" {
 				return fmt.Errorf("organization is required: use --org flag, TFE_ORG env, or set 'org' in config file")
 			}
 			if workspaceName == "" {
-				return fmt.Errorf("workspace is required: use --workspace (-w) flag")
+				return fmt.Errorf("workspace is required: use --workspace/-w flag")
 			}
 
 			cat := tfe.CategoryTerraform

--- a/internal/cmd/workspace/list.go
+++ b/internal/cmd/workspace/list.go
@@ -26,8 +26,9 @@ func newCmdWorkspaceListWith(clientFn wsListClientFactory) *cobra.Command {
 	var search string
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List workspaces in an organization",
+		Use:          "list",
+		Short:        "List workspaces in an organization",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org := viper.GetString("org")
 			if org == "" {

--- a/internal/cmd/workspace/show.go
+++ b/internal/cmd/workspace/show.go
@@ -25,9 +25,10 @@ func newCmdWorkspaceShow() *cobra.Command {
 
 func newCmdWorkspaceShowWith(clientFn wsShowClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show <name>",
-		Short: "Show workspace details",
-		Args:  cobra.ExactArgs(1),
+		Use:          "show <name>",
+		Short:        "Show workspace details",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org := viper.GetString("org")
 			if org == "" {


### PR DESCRIPTION
## Summary
- Standardize `--workspace` flag notation to `--workspace/-w` format across all error messages
- Add `SilenceUsage: true` to prevent help display on non-syntax errors for all commands
- Update test expectations to match new error message format

## Changes

### 1. Standardized `--workspace` flag notation
Fixed inconsistent error message formatting from `--workspace (-w)` and `--workspace` to unified `--workspace/-w` format in:
- `internal/cmd/run/list.go`
- `internal/cmd/run/show.go` (2 occurrences)
- `internal/cmd/variable/set.go`
- `internal/cmd/variable/delete.go`
- `internal/cmd/variable/list.go`

### 2. Added `SilenceUsage: true` to commands
Added `SilenceUsage: true` to prevent unnecessary help text display on non-syntax errors (API errors, validation errors, etc.) in:
- `internal/cmd/workspace/show.go`
- `internal/cmd/workspace/list.go`
- `internal/cmd/drift/show.go`
- `internal/cmd/drift/list.go`
- `internal/cmd/variable/list.go`
- `internal/cmd/variable/set.go`
- `internal/cmd/variable/delete.go`
- `internal/cmd/org/show.go`
- `internal/cmd/org/list.go`
- `internal/cmd/project/list.go`
- `internal/cmd/config/set.go`
- `internal/cmd/config/get.go`
- `internal/cmd/config/list.go`

### 3. Updated test expectations
Updated test expectations in `internal/cmd/run/show_test.go` to match new error message format.

## Test plan
- [x] All existing tests pass
- [x] Build completes successfully
- [x] Error messages are now consistent across all commands
- [x] Help text is no longer displayed for non-syntax errors

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)