### PR TITLE
Add auto-detection of GitHub repository for --pr flag

### DIFF
--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -65,3 +65,81 @@ func TestGetRunIDFromPR(t *testing.T) {
 		})
 	}
 }
+
+// TestParseGitHubRepository tests the parseGitHubRepository function.
+func TestParseGitHubRepository(t *testing.T) {
+	tests := []struct {
+		name         string
+		remoteURL    string
+		expectedRepo string
+		expectError  bool
+	}{
+		{
+			name:         "SSH format with .git",
+			remoteURL:    "git@github.com:nnstt1/hcpt.git",
+			expectedRepo: "nnstt1/hcpt",
+			expectError:  false,
+		},
+		{
+			name:         "SSH format without .git",
+			remoteURL:    "git@github.com:owner/repo",
+			expectedRepo: "owner/repo",
+			expectError:  false,
+		},
+		{
+			name:         "HTTPS format with .git",
+			remoteURL:    "https://github.com/nnstt1/hcpt.git",
+			expectedRepo: "nnstt1/hcpt",
+			expectError:  false,
+		},
+		{
+			name:         "HTTPS format without .git",
+			remoteURL:    "https://github.com/owner/repo",
+			expectedRepo: "owner/repo",
+			expectError:  false,
+		},
+		{
+			name:         "GitLab SSH",
+			remoteURL:    "git@gitlab.com:owner/repo.git",
+			expectedRepo: "",
+			expectError:  true,
+		},
+		{
+			name:         "GitLab HTTPS",
+			remoteURL:    "https://gitlab.com/owner/repo.git",
+			expectedRepo: "",
+			expectError:  true,
+		},
+		{
+			name:         "Bitbucket SSH",
+			remoteURL:    "git@bitbucket.org:owner/repo.git",
+			expectedRepo: "",
+			expectError:  true,
+		},
+		{
+			name:         "invalid format",
+			remoteURL:    "not-a-valid-url",
+			expectedRepo: "",
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, err := parseGitHubRepository(tt.remoteURL)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if repo != tt.expectedRepo {
+					t.Errorf("expected repo %q, got %q", tt.expectedRepo, repo)
+				}
+			}
+		})
+	}
+}

--- a/internal/cmd/run/show.go
+++ b/internal/cmd/run/show.go
@@ -91,7 +91,12 @@ func newCmdRunShowWith(clientFn runShowClientFactory) *cobra.Command {
 			}
 
 			if prNumber > 0 && repoFullName == "" {
-				return fmt.Errorf("--repo is required when using --pr")
+				// Try to auto-detect repository from Git remote
+				detectedRepo, err := client.DetectGitHubRepository()
+				if err != nil {
+					return err
+				}
+				repoFullName = detectedRepo
 			}
 
 			if repoFullName != "" && !strings.Contains(repoFullName, "/") {

--- a/internal/cmd/run/show_test.go
+++ b/internal/cmd/run/show_test.go
@@ -990,29 +990,6 @@ func (m *mockRunShowServiceWithWatchError) ReadPlanJSONOutput(_ context.Context,
 	return nil, fmt.Errorf("ReadPlanJSONOutput not implemented in mockRunShowServiceWithWatchError")
 }
 
-func TestRunShow_WithPR_MissingRepo(t *testing.T) {
-	viper.Reset()
-
-	cmd := newCmdRunShowWith(func() (runShowService, error) {
-		return &mockRunShowService{}, nil
-	})
-
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SilenceUsage = true
-	cmd.SilenceErrors = true
-	cmd.SetArgs([]string{"--pr", "42"})
-
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "--repo is required when using --pr") {
-		t.Errorf("expected '--repo is required' error, got: %v", err)
-	}
-}
-
 func TestRunShow_WithPR_InvalidRepoFormat(t *testing.T) {
 	viper.Reset()
 


### PR DESCRIPTION
## Summary
- Added auto-detection of GitHub repository from Git remote when `--repo` flag is omitted
- `--repo` flag is now optional when using `--pr` in `hcpt run show` command
- Supports both SSH (`git@github.com:owner/repo.git`) and HTTPS (`https://github.com/owner/repo.git`) formats
- `--repo` flag takes precedence when explicitly specified

## Changes
- Added `DetectGitHubRepository()` function in `internal/client/github.go` to auto-detect repository from Git remote
- Added `parseGitHubRepository()` function to parse owner/repo from Git remote URL
- Modified `run show` command to auto-detect repository when `--repo` is not specified
- Added comprehensive tests for Git remote URL parsing

## Error Handling
The implementation provides clear error messages for:
- Not a Git repository: "git repository not found in current directory"
- No Git remote found: "no git remote found in current directory"
- Non-GitHub remote: "git remote is not a GitHub repository: {url}"

All error messages include a helpful note to specify `--repo` flag as an alternative.

## Test Plan
- [x] All existing tests pass
- [x] New tests for `parseGitHubRepository()` cover SSH and HTTPS formats
- [x] Tested auto-detection with actual Git repository
- [x] Verified `--repo` flag takes precedence when specified
- [x] Linter passes

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)