### PR TITLE
Add Renovate configuration for dependency management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "schedule": [
+    "after 9am and before 5pm every weekday",
+    "every weekend"
+  ],
+  "timezone": "Asia/Tokyo",
+  "labels": [
+    "dependencies"
+  ],
+  "assignees": [
+    "nnstt1"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "Go dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "actions"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": [
+      "security"
+    ],
+    "assignees": [
+      "nnstt1"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Added Renovate configuration to automatically manage Go modules and GitHub Actions dependencies.

## Changes

- Added `.github/renovate.json`
  - Automatic updates for Go modules
  - Automatic updates for GitHub Actions
  - Scheduled to run on weekdays (9am-5pm JST) and weekends
  - Grouped updates with `dependencies` label
  - Security alerts prioritized with `security` label

## Testing

- Renovate bot will scan the repository and create PRs as needed
- An onboarding PR will be created on first run

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)