### PR TITLE
Disable Renovate Dependency Dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
     "every weekend"
   ],
   "timezone": "Asia/Tokyo",
+  "dependencyDashboard": false,
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Summary

Disabled the Dependency Dashboard feature in Renovate configuration.

## Changes

- Added `"dependencyDashboard": false` to `.github/renovate.json`
- Renovate will now create update PRs directly without creating a dashboard issue

## Reference

- https://docs.renovatebot.com/key-concepts/dashboard/

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)