### PR TITLE
Add variable import command for bulk importing from .tfvars files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 hcpt
 dist/
+test-import.tfvars

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	github.com/zclconf/go-cty v1.16.3
 	go.yaml.in/yaml/v3 v3.0.4
 )
 
@@ -32,7 +33,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/zclconf/go-cty v1.16.3 // indirect
 	golang.org/x/mod v0.26.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-slug v0.16.8 h1:f4/sDZqRsxx006HrE6e9BE5xO9lWXydKhVoH6Kb0v1M=
 github.com/hashicorp/go-slug v0.16.8/go.mod h1:hB4mUcVHl4RPu0205s0fwmB9i31MxQgeafGkko3FD+Y=
-github.com/hashicorp/go-tfe v1.100.0 h1:nULxQ4xcD4E4DBrfR3+wdlu4Iu9tj9d/PtyMQt5WztM=
-github.com/hashicorp/go-tfe v1.100.0/go.mod h1:JIqznMwZd8flUhPif5d2sprKcFkD4sWJSIQ6E8iAuIA=
 github.com/hashicorp/go-tfe v1.101.0 h1:Nq9CTfxiFyXqWSnfh2tC81ZU2pGcW6QUMKU43RmibrU=
 github.com/hashicorp/go-tfe v1.101.0/go.mod h1:JIqznMwZd8flUhPif5d2sprKcFkD4sWJSIQ6E8iAuIA=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=

--- a/internal/cmd/variable/import.go
+++ b/internal/cmd/variable/import.go
@@ -1,0 +1,197 @@
+package variable
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/nnstt1/hcpt/internal/client"
+	"github.com/nnstt1/hcpt/internal/parser"
+	"github.com/nnstt1/hcpt/internal/prompt"
+)
+
+type variableImportService interface {
+	client.WorkspaceService
+	client.VariableService
+}
+
+type variableImportClientFactory func() (variableImportService, error)
+
+func defaultVariableImportClientFactory() (variableImportService, error) {
+	return client.NewClientWrapper()
+}
+
+func newCmdVariableImport() *cobra.Command {
+	return newCmdVariableImportWith(defaultVariableImportClientFactory)
+}
+
+func newCmdVariableImportWith(clientFn variableImportClientFactory) *cobra.Command {
+	var (
+		workspaceName string
+		category      string
+		sensitive     bool
+		overwrite     bool
+		dryRun        bool
+	)
+
+	cmd := &cobra.Command{
+		Use:          "import <file>",
+		Short:        "Import variables from a .tfvars or .tfvars.json file",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			filename := args[0]
+			org := viper.GetString("org")
+			if org == "" {
+				return fmt.Errorf("organization is required: use --org flag, TFE_ORG env, or set 'org' in config file")
+			}
+			if workspaceName == "" {
+				return fmt.Errorf("workspace is required: use --workspace/-w flag")
+			}
+
+			svc, err := clientFn()
+			if err != nil {
+				return err
+			}
+
+			categoryType := tfe.CategoryTerraform
+			if category == "env" {
+				categoryType = tfe.CategoryEnv
+			}
+
+			return runVariableImport(svc, org, workspaceName, filename, categoryType, sensitive, overwrite, dryRun)
+		},
+	}
+
+	cmd.Flags().StringVarP(&workspaceName, "workspace", "w", "", "workspace name (required)")
+	cmd.Flags().StringVar(&category, "category", "terraform", "variable category (terraform or env)")
+	cmd.Flags().BoolVar(&sensitive, "sensitive", false, "mark all imported variables as sensitive")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "auto-overwrite existing variables without prompting")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview without actually creating/updating variables")
+
+	return cmd
+}
+
+func runVariableImport(svc variableImportService, org, workspaceName, filename string,
+	category tfe.CategoryType, sensitive, overwrite, dryRun bool) error {
+	ctx := context.Background()
+
+	// 1. ファイル存在チェック
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return fmt.Errorf("file not found: %s", filename)
+	}
+
+	// 2. ファイルパース
+	vars, err := parser.ParseFile(filename)
+	if err != nil {
+		return fmt.Errorf("failed to parse file: %w", err)
+	}
+
+	if len(vars) == 0 {
+		fmt.Println("No variables found in file")
+		return nil
+	}
+
+	// 3. ワークスペース取得
+	ws, err := svc.ReadWorkspace(ctx, org, workspaceName)
+	if err != nil {
+		return fmt.Errorf("failed to read workspace %q: %w", workspaceName, err)
+	}
+
+	// 4. 既存変数取得（重複チェック用）
+	varList, err := svc.ListVariables(ctx, ws.ID, &tfe.VariableListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list variables: %w", err)
+	}
+
+	existingVars := make(map[string]*tfe.Variable)
+	for _, v := range varList.Items {
+		if v.Category == category {
+			existingVars[v.Key] = v
+		}
+	}
+
+	// 5. 変数を順次処理
+	createdCount := 0
+	updatedCount := 0
+	skippedCount := 0
+
+	for i, variable := range vars {
+		fmt.Printf("[%d/%d] Setting variable: %s...\n", i+1, len(vars), variable.Key)
+
+		existing, exists := existingVars[variable.Key]
+
+		// 重複チェック
+		if exists && !overwrite && !dryRun {
+			ok, err := prompt.Confirm(fmt.Sprintf("Variable %q already exists. Overwrite?", variable.Key))
+			if err != nil {
+				return fmt.Errorf("failed to read user input: %w", err)
+			}
+			if !ok {
+				fmt.Printf("  Skipped variable %q\n", variable.Key)
+				skippedCount++
+				continue
+			}
+		}
+
+		// Dry-run チェック
+		if dryRun {
+			if exists {
+				fmt.Printf("  [DRY RUN] Would update variable %q\n", variable.Key)
+			} else {
+				fmt.Printf("  [DRY RUN] Would create variable %q\n", variable.Key)
+			}
+			continue
+		}
+
+		// Update or Create
+		if exists {
+			opts := tfe.VariableUpdateOptions{
+				Key:       &variable.Key,
+				Value:     &variable.Value,
+				Sensitive: &sensitive,
+				HCL:       &variable.IsHCL,
+			}
+			_, err := svc.UpdateVariable(ctx, ws.ID, existing.ID, opts)
+			if err != nil {
+				return fmt.Errorf("failed to update variable %q: %w", variable.Key, err)
+			}
+			fmt.Printf("  ✓ Updated variable %q\n", variable.Key)
+			updatedCount++
+		} else {
+			opts := tfe.VariableCreateOptions{
+				Key:       &variable.Key,
+				Value:     &variable.Value,
+				Category:  &category,
+				Sensitive: &sensitive,
+				HCL:       &variable.IsHCL,
+			}
+			_, err := svc.CreateVariable(ctx, ws.ID, opts)
+			if err != nil {
+				return fmt.Errorf("failed to create variable %q: %w", variable.Key, err)
+			}
+			fmt.Printf("  ✓ Created variable %q\n", variable.Key)
+			createdCount++
+		}
+	}
+
+	// 6. サマリー表示
+	if !dryRun {
+		fmt.Printf("\nSuccessfully imported %d variable(s) to workspace %q\n", createdCount+updatedCount, workspaceName)
+		if createdCount > 0 {
+			fmt.Printf("  Created: %d\n", createdCount)
+		}
+		if updatedCount > 0 {
+			fmt.Printf("  Updated: %d\n", updatedCount)
+		}
+		if skippedCount > 0 {
+			fmt.Printf("  Skipped: %d\n", skippedCount)
+		}
+	}
+
+	return nil
+}

--- a/internal/cmd/variable/import_test.go
+++ b/internal/cmd/variable/import_test.go
@@ -1,0 +1,258 @@
+package variable
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/spf13/viper"
+)
+
+func TestVariableImport_Create(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockVariableListService{
+		workspace: &tfe.Workspace{ID: "ws-abc123", Name: "my-ws"},
+		variables: []*tfe.Variable{},
+		createVar: &tfe.Variable{},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	filename := filepath.Join("testdata", "test.tfvars")
+	err := runVariableImport(mock, "test-org", "my-ws", filename, tfe.CategoryTerraform, false, false, false)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	if !strings.Contains(got, "Successfully imported") {
+		t.Errorf("expected success message, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Created: 3") {
+		t.Errorf("expected 'Created: 3', got:\n%s", got)
+	}
+}
+
+func TestVariableImport_Update(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockVariableListService{
+		workspace: &tfe.Workspace{ID: "ws-abc123", Name: "my-ws"},
+		variables: []*tfe.Variable{
+			{
+				ID:       "var-123",
+				Key:      "region",
+				Value:    "ap-northeast-1",
+				Category: tfe.CategoryTerraform,
+			},
+		},
+		updateVar: &tfe.Variable{},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	filename := filepath.Join("testdata", "test.tfvars.json")
+	// overwrite=true で自動上書き
+	err := runVariableImport(mock, "test-org", "my-ws", filename, tfe.CategoryTerraform, false, true, false)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	if !strings.Contains(got, "Successfully imported") {
+		t.Errorf("expected success message, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Updated: 1") {
+		t.Errorf("expected 'Updated: 1', got:\n%s", got)
+	}
+	if !strings.Contains(got, "Created: 1") {
+		t.Errorf("expected 'Created: 1', got:\n%s", got)
+	}
+}
+
+func TestVariableImport_DryRun(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockVariableListService{
+		workspace: &tfe.Workspace{ID: "ws-abc123", Name: "my-ws"},
+		variables: []*tfe.Variable{},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	filename := filepath.Join("testdata", "test.tfvars")
+	err := runVariableImport(mock, "test-org", "my-ws", filename, tfe.CategoryTerraform, false, false, true)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	if !strings.Contains(got, "[DRY RUN]") {
+		t.Errorf("expected '[DRY RUN]' message, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Would create variable") {
+		t.Errorf("expected 'Would create variable' message, got:\n%s", got)
+	}
+}
+
+func TestVariableImport_FileNotFound(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockVariableListService{
+		workspace: &tfe.Workspace{ID: "ws-abc123", Name: "my-ws"},
+	}
+
+	err := runVariableImport(mock, "test-org", "my-ws", "nonexistent.tfvars", tfe.CategoryTerraform, false, false, false)
+
+	if err == nil {
+		t.Fatal("expected error for non-existent file, got nil")
+	}
+	if !strings.Contains(err.Error(), "file not found") {
+		t.Errorf("expected 'file not found' error, got: %v", err)
+	}
+}
+
+func TestVariableImport_WorkspaceNotFound(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockVariableListService{
+		readErr: fmt.Errorf("workspace not found"),
+	}
+
+	filename := filepath.Join("testdata", "test.tfvars")
+	err := runVariableImport(mock, "test-org", "my-ws", filename, tfe.CategoryTerraform, false, false, false)
+
+	if err == nil {
+		t.Fatal("expected error for workspace not found, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to read workspace") {
+		t.Errorf("expected 'failed to read workspace' error, got: %v", err)
+	}
+}
+
+func TestVariableImport_ListVariablesError(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockVariableListService{
+		workspace: &tfe.Workspace{ID: "ws-abc123", Name: "my-ws"},
+		listErr:   fmt.Errorf("API error"),
+	}
+
+	filename := filepath.Join("testdata", "test.tfvars")
+	err := runVariableImport(mock, "test-org", "my-ws", filename, tfe.CategoryTerraform, false, false, false)
+
+	if err == nil {
+		t.Fatal("expected error for list variables failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to list variables") {
+		t.Errorf("expected 'failed to list variables' error, got: %v", err)
+	}
+}
+
+func TestVariableImport_CreateError(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockVariableListService{
+		workspace: &tfe.Workspace{ID: "ws-abc123", Name: "my-ws"},
+		variables: []*tfe.Variable{},
+		createErr: fmt.Errorf("API error"),
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	filename := filepath.Join("testdata", "test.tfvars")
+	err := runVariableImport(mock, "test-org", "my-ws", filename, tfe.CategoryTerraform, false, false, false)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	if err == nil {
+		t.Fatal("expected error for create variable failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to create variable") {
+		t.Errorf("expected 'failed to create variable' error, got: %v", err)
+	}
+}
+
+func TestVariableImport_EmptyFile(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	// Create empty test file
+	tmpFile := filepath.Join(os.TempDir(), "empty.tfvars.json")
+	err := os.WriteFile(tmpFile, []byte("{}"), 0644)
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer func() { _ = os.Remove(tmpFile) }()
+
+	mock := &mockVariableListService{
+		workspace: &tfe.Workspace{ID: "ws-abc123", Name: "my-ws"},
+		variables: []*tfe.Variable{},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = runVariableImport(mock, "test-org", "my-ws", tmpFile, tfe.CategoryTerraform, false, false, false)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	if !strings.Contains(got, "No variables found in file") {
+		t.Errorf("expected 'No variables found' message, got:\n%s", got)
+	}
+}

--- a/internal/cmd/variable/testdata/test.tfvars
+++ b/internal/cmd/variable/testdata/test.tfvars
@@ -1,0 +1,3 @@
+region = "us-east-1"
+instance_count = 3
+enable_monitoring = true

--- a/internal/cmd/variable/testdata/test.tfvars.json
+++ b/internal/cmd/variable/testdata/test.tfvars.json
@@ -1,0 +1,4 @@
+{
+  "region": "us-west-2",
+  "instance_count": 5
+}

--- a/internal/cmd/variable/variable.go
+++ b/internal/cmd/variable/variable.go
@@ -15,6 +15,7 @@ func NewCmdVariable() *cobra.Command {
 	cmd.AddCommand(newCmdVariableList())
 	cmd.AddCommand(newCmdVariableSet())
 	cmd.AddCommand(newCmdVariableDelete())
+	cmd.AddCommand(newCmdVariableImport())
 
 	return cmd
 }

--- a/internal/parser/testdata/complex.tfvars
+++ b/internal/parser/testdata/complex.tfvars
@@ -1,0 +1,6 @@
+region = "us-east-1"
+tags = {
+  Environment = "production"
+  Owner       = "team-a"
+}
+subnets = ["10.0.1.0/24", "10.0.2.0/24"]

--- a/internal/parser/testdata/complex.tfvars.json
+++ b/internal/parser/testdata/complex.tfvars.json
@@ -1,0 +1,8 @@
+{
+  "region": "us-east-1",
+  "tags": {
+    "Environment": "production",
+    "Owner": "team-a"
+  },
+  "subnets": ["10.0.1.0/24", "10.0.2.0/24"]
+}

--- a/internal/parser/testdata/invalid.json
+++ b/internal/parser/testdata/invalid.json
@@ -1,0 +1,4 @@
+{
+  "region": "us-east-1",
+  "invalid":
+}

--- a/internal/parser/testdata/invalid.tfvars
+++ b/internal/parser/testdata/invalid.tfvars
@@ -1,0 +1,2 @@
+region = "us-east-1
+# Invalid: missing closing quote

--- a/internal/parser/testdata/simple.tfvars
+++ b/internal/parser/testdata/simple.tfvars
@@ -1,0 +1,3 @@
+region = "us-east-1"
+instance_count = 3
+enable_monitoring = true

--- a/internal/parser/testdata/simple.tfvars.json
+++ b/internal/parser/testdata/simple.tfvars.json
@@ -1,0 +1,5 @@
+{
+  "region": "us-east-1",
+  "instance_count": 3,
+  "enable_monitoring": true
+}

--- a/internal/parser/tfvars.go
+++ b/internal/parser/tfvars.go
@@ -1,0 +1,137 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Variable represents a parsed variable with its key, value, and type information.
+type Variable struct {
+	Key   string
+	Value string
+	IsHCL bool
+}
+
+// ParseFile parses a .tfvars or .tfvars.json file and returns a list of variables.
+func ParseFile(filename string) ([]Variable, error) {
+	ext := strings.ToLower(filepath.Ext(filename))
+
+	switch ext {
+	case ".tfvars":
+		return parseHCLFile(filename)
+	case ".json":
+		return parseJSONFile(filename)
+	default:
+		// Check for .tfvars.json pattern
+		if strings.HasSuffix(strings.ToLower(filename), ".tfvars.json") {
+			return parseJSONFile(filename)
+		}
+		return nil, fmt.Errorf("unsupported file format: %s (expected .tfvars, .tfvars.json, or .json)", ext)
+	}
+}
+
+// parseHCLFile parses a HCL-formatted .tfvars file.
+func parseHCLFile(filename string) ([]Variable, error) {
+	parser := hclparse.NewParser()
+	file, diag := parser.ParseHCLFile(filename)
+	if diag.HasErrors() {
+		return nil, fmt.Errorf("failed to parse HCL: %w", diag)
+	}
+
+	attrs, diag := file.Body.JustAttributes()
+	if diag.HasErrors() {
+		return nil, fmt.Errorf("failed to get attributes: %w", diag)
+	}
+
+	vars := make([]Variable, 0, len(attrs))
+	for name, attr := range attrs {
+		val, diag := attr.Expr.Value(nil)
+		if diag.HasErrors() {
+			return nil, fmt.Errorf("failed to evaluate expression for %q: %w", name, diag)
+		}
+
+		v := Variable{Key: name}
+		switch {
+		case val.Type() == cty.String:
+			v.Value = val.AsString()
+			v.IsHCL = false
+		case val.Type() == cty.Number:
+			bf := val.AsBigFloat()
+			// Format as integer if possible, otherwise as float
+			if bf.IsInt() {
+				i, _ := bf.Int64()
+				v.Value = strconv.FormatInt(i, 10)
+			} else {
+				f, _ := bf.Float64()
+				v.Value = strconv.FormatFloat(f, 'f', -1, 64)
+			}
+			v.IsHCL = false
+		case val.Type() == cty.Bool:
+			v.Value = strconv.FormatBool(val.True())
+			v.IsHCL = false
+		default:
+			// Complex type: extract HCL source code
+			bytes := file.Bytes[attr.Expr.Range().Start.Byte:attr.Expr.Range().End.Byte]
+			v.Value = string(bytes)
+			v.IsHCL = true
+		}
+		vars = append(vars, v)
+	}
+
+	return vars, nil
+}
+
+// parseJSONFile parses a JSON-formatted .tfvars.json file.
+func parseJSONFile(filename string) ([]Variable, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	vars := make([]Variable, 0, len(raw))
+	for key, val := range raw {
+		v := Variable{Key: key}
+
+		switch t := val.(type) {
+		case string:
+			v.Value = t
+			v.IsHCL = false
+		case float64:
+			// Format as integer if possible, otherwise as float
+			if t == float64(int64(t)) {
+				v.Value = strconv.FormatInt(int64(t), 10)
+			} else {
+				v.Value = strconv.FormatFloat(t, 'f', -1, 64)
+			}
+			v.IsHCL = false
+		case bool:
+			v.Value = strconv.FormatBool(t)
+			v.IsHCL = false
+		case []interface{}, map[string]interface{}:
+			// Complex type: convert to JSON string and mark as HCL
+			bytes, err := json.Marshal(t)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal complex type for variable %q: %w", key, err)
+			}
+			v.Value = string(bytes)
+			v.IsHCL = true
+		default:
+			return nil, fmt.Errorf("unsupported type %T for variable %q", t, key)
+		}
+		vars = append(vars, v)
+	}
+
+	return vars, nil
+}

--- a/internal/parser/tfvars_test.go
+++ b/internal/parser/tfvars_test.go
@@ -1,0 +1,286 @@
+package parser
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParseFile_SimpleHCL(t *testing.T) {
+	vars, err := ParseFile(filepath.Join("testdata", "simple.tfvars"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(vars) != 3 {
+		t.Fatalf("expected 3 variables, got %d", len(vars))
+	}
+
+	// Check region
+	found := false
+	for _, v := range vars {
+		if v.Key == "region" {
+			found = true
+			if v.Value != "us-east-1" {
+				t.Errorf("expected region value to be 'us-east-1', got %q", v.Value)
+			}
+			if v.IsHCL {
+				t.Errorf("expected region IsHCL to be false, got true")
+			}
+		}
+	}
+	if !found {
+		t.Error("region variable not found")
+	}
+
+	// Check instance_count
+	found = false
+	for _, v := range vars {
+		if v.Key == "instance_count" {
+			found = true
+			if v.Value != "3" {
+				t.Errorf("expected instance_count value to be '3', got %q", v.Value)
+			}
+			if v.IsHCL {
+				t.Errorf("expected instance_count IsHCL to be false, got true")
+			}
+		}
+	}
+	if !found {
+		t.Error("instance_count variable not found")
+	}
+
+	// Check enable_monitoring
+	found = false
+	for _, v := range vars {
+		if v.Key == "enable_monitoring" {
+			found = true
+			if v.Value != "true" {
+				t.Errorf("expected enable_monitoring value to be 'true', got %q", v.Value)
+			}
+			if v.IsHCL {
+				t.Errorf("expected enable_monitoring IsHCL to be false, got true")
+			}
+		}
+	}
+	if !found {
+		t.Error("enable_monitoring variable not found")
+	}
+}
+
+func TestParseFile_ComplexHCL(t *testing.T) {
+	vars, err := ParseFile(filepath.Join("testdata", "complex.tfvars"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(vars) != 3 {
+		t.Fatalf("expected 3 variables, got %d", len(vars))
+	}
+
+	// Check region (simple type)
+	found := false
+	for _, v := range vars {
+		if v.Key == "region" {
+			found = true
+			if v.Value != "us-east-1" {
+				t.Errorf("expected region value to be 'us-east-1', got %q", v.Value)
+			}
+			if v.IsHCL {
+				t.Errorf("expected region IsHCL to be false, got true")
+			}
+		}
+	}
+	if !found {
+		t.Error("region variable not found")
+	}
+
+	// Check tags (complex type - map)
+	found = false
+	for _, v := range vars {
+		if v.Key == "tags" {
+			found = true
+			if !v.IsHCL {
+				t.Errorf("expected tags IsHCL to be true, got false")
+			}
+			// Value should be HCL source code
+			if v.Value == "" {
+				t.Error("expected tags value to be non-empty HCL source")
+			}
+		}
+	}
+	if !found {
+		t.Error("tags variable not found")
+	}
+
+	// Check subnets (complex type - list)
+	found = false
+	for _, v := range vars {
+		if v.Key == "subnets" {
+			found = true
+			if !v.IsHCL {
+				t.Errorf("expected subnets IsHCL to be true, got false")
+			}
+			// Value should be HCL source code
+			if v.Value == "" {
+				t.Error("expected subnets value to be non-empty HCL source")
+			}
+		}
+	}
+	if !found {
+		t.Error("subnets variable not found")
+	}
+}
+
+func TestParseFile_SimpleJSON(t *testing.T) {
+	vars, err := ParseFile(filepath.Join("testdata", "simple.tfvars.json"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(vars) != 3 {
+		t.Fatalf("expected 3 variables, got %d", len(vars))
+	}
+
+	// Check region
+	found := false
+	for _, v := range vars {
+		if v.Key == "region" {
+			found = true
+			if v.Value != "us-east-1" {
+				t.Errorf("expected region value to be 'us-east-1', got %q", v.Value)
+			}
+			if v.IsHCL {
+				t.Errorf("expected region IsHCL to be false, got true")
+			}
+		}
+	}
+	if !found {
+		t.Error("region variable not found")
+	}
+
+	// Check instance_count
+	found = false
+	for _, v := range vars {
+		if v.Key == "instance_count" {
+			found = true
+			if v.Value != "3" {
+				t.Errorf("expected instance_count value to be '3', got %q", v.Value)
+			}
+			if v.IsHCL {
+				t.Errorf("expected instance_count IsHCL to be false, got true")
+			}
+		}
+	}
+	if !found {
+		t.Error("instance_count variable not found")
+	}
+
+	// Check enable_monitoring
+	found = false
+	for _, v := range vars {
+		if v.Key == "enable_monitoring" {
+			found = true
+			if v.Value != "true" {
+				t.Errorf("expected enable_monitoring value to be 'true', got %q", v.Value)
+			}
+			if v.IsHCL {
+				t.Errorf("expected enable_monitoring IsHCL to be false, got true")
+			}
+		}
+	}
+	if !found {
+		t.Error("enable_monitoring variable not found")
+	}
+}
+
+func TestParseFile_ComplexJSON(t *testing.T) {
+	vars, err := ParseFile(filepath.Join("testdata", "complex.tfvars.json"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(vars) != 3 {
+		t.Fatalf("expected 3 variables, got %d", len(vars))
+	}
+
+	// Check region (simple type)
+	found := false
+	for _, v := range vars {
+		if v.Key == "region" {
+			found = true
+			if v.Value != "us-east-1" {
+				t.Errorf("expected region value to be 'us-east-1', got %q", v.Value)
+			}
+			if v.IsHCL {
+				t.Errorf("expected region IsHCL to be false, got true")
+			}
+		}
+	}
+	if !found {
+		t.Error("region variable not found")
+	}
+
+	// Check tags (complex type - map)
+	found = false
+	for _, v := range vars {
+		if v.Key == "tags" {
+			found = true
+			if !v.IsHCL {
+				t.Errorf("expected tags IsHCL to be true, got false")
+			}
+			// Value should be JSON string
+			if v.Value == "" {
+				t.Error("expected tags value to be non-empty JSON string")
+			}
+		}
+	}
+	if !found {
+		t.Error("tags variable not found")
+	}
+
+	// Check subnets (complex type - list)
+	found = false
+	for _, v := range vars {
+		if v.Key == "subnets" {
+			found = true
+			if !v.IsHCL {
+				t.Errorf("expected subnets IsHCL to be true, got false")
+			}
+			// Value should be JSON string
+			if v.Value == "" {
+				t.Error("expected subnets value to be non-empty JSON string")
+			}
+		}
+	}
+	if !found {
+		t.Error("subnets variable not found")
+	}
+}
+
+func TestParseFile_InvalidHCL(t *testing.T) {
+	_, err := ParseFile(filepath.Join("testdata", "invalid.tfvars"))
+	if err == nil {
+		t.Fatal("expected error for invalid HCL, got nil")
+	}
+}
+
+func TestParseFile_InvalidJSON(t *testing.T) {
+	_, err := ParseFile(filepath.Join("testdata", "invalid.json"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestParseFile_UnsupportedExtension(t *testing.T) {
+	_, err := ParseFile("test.txt")
+	if err == nil {
+		t.Fatal("expected error for unsupported extension, got nil")
+	}
+}
+
+func TestParseFile_FileNotFound(t *testing.T) {
+	_, err := ParseFile(filepath.Join("testdata", "nonexistent.tfvars"))
+	if err == nil {
+		t.Fatal("expected error for non-existent file, got nil")
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,0 +1,30 @@
+package prompt
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Confirm prompts user for Y/n confirmation.
+// Returns false (No) by default when user presses Enter or inputs nothing.
+// Returns true only when user explicitly inputs 'y' or 'Y'.
+func Confirm(message string) (bool, error) {
+	fmt.Printf("%s [y/N]: ", message)
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	input = strings.TrimSpace(strings.ToLower(input))
+
+	// デフォルト: No (安全性重視)
+	if input == "y" {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1,0 +1,206 @@
+package prompt
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestConfirm_Yes(t *testing.T) {
+	// Create a pipe to simulate stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	// Replace os.Stdin temporarily
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	// Write "y\n" to the pipe
+	go func() {
+		defer func() { _ = w.Close() }()
+		_, _ = w.Write([]byte("y\n"))
+	}()
+
+	result, err := Confirm("Test question")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !result {
+		t.Error("expected true for 'y' input, got false")
+	}
+}
+
+func TestConfirm_YesUpperCase(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	go func() {
+		defer func() { _ = w.Close() }()
+		_, _ = w.Write([]byte("Y\n"))
+	}()
+
+	result, err := Confirm("Test question")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !result {
+		t.Error("expected true for 'Y' input, got false")
+	}
+}
+
+func TestConfirm_No(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	go func() {
+		defer func() { _ = w.Close() }()
+		_, _ = w.Write([]byte("n\n"))
+	}()
+
+	result, err := Confirm("Test question")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result {
+		t.Error("expected false for 'n' input, got true")
+	}
+}
+
+func TestConfirm_EmptyEnter(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	go func() {
+		defer func() { _ = w.Close() }()
+		_, _ = w.Write([]byte("\n"))
+	}()
+
+	result, err := Confirm("Test question")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result {
+		t.Error("expected false (default No) for empty Enter, got true")
+	}
+}
+
+func TestConfirm_OtherInput(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	go func() {
+		defer func() { _ = w.Close() }()
+		_, _ = w.Write([]byte("foo\n"))
+	}()
+
+	result, err := Confirm("Test question")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result {
+		t.Error("expected false for other input, got true")
+	}
+}
+
+func TestConfirm_Error(t *testing.T) {
+	// Close the read end immediately to simulate an error
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	_ = r.Close()
+	_ = w.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	_, err = Confirm("Test question")
+	if err == nil {
+		t.Error("expected error when stdin is closed, got nil")
+	}
+}
+
+func TestConfirm_MessageFormat(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	oldStdin := os.Stdin
+	oldStdout := os.Stdout
+	defer func() {
+		os.Stdin = oldStdin
+		os.Stdout = oldStdout
+	}()
+
+	// Capture stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create output pipe: %v", err)
+	}
+
+	// Write input data and close the write end
+	_, _ = w.Write([]byte("n\n"))
+	_ = w.Close()
+
+	// Set stdin and stdout
+	os.Stdin = r
+	os.Stdout = wOut
+
+	// Run Confirm in a goroutine
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = Confirm("Do you want to proceed?")
+		_ = wOut.Close()
+	}()
+
+	// Read captured output
+	outputBytes, err := io.ReadAll(rOut)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	// Wait for Confirm to finish
+	<-done
+	_ = r.Close()
+
+	output := string(outputBytes)
+	expectedPrompt := "Do you want to proceed? [y/N]: "
+	if output != expectedPrompt {
+		t.Errorf("expected prompt %q, got %q", expectedPrompt, output)
+	}
+}


### PR DESCRIPTION
## Summary

This PR implements the `variable import` command to enable bulk importing of variables from `.tfvars` or `.tfvars.json` files into HCP Terraform workspaces.

- ✅ Support for both HCL (`.tfvars`) and JSON (`.tfvars.json`, `.json`) formats
- ✅ Automatic handling of simple and complex variable types
- ✅ Interactive prompts for existing variable conflicts with safe defaults
- ✅ Dry-run mode for previewing changes before applying
- ✅ Comprehensive test coverage including race detector checks

## Test plan

- [x] Unit tests for parser (HCL and JSON)
- [x] Unit tests for prompt functionality
- [x] Unit tests for import command
- [x] All tests pass with race detector
- [x] golangci-lint passes with 0 issues
- [x] Manual testing with sample `.tfvars` and `.tfvars.json` files

## Usage

```bash
# Preview import without applying changes
hcpt variable import variables.tfvars -w my-workspace --dry-run

# Import with interactive prompts for conflicts
hcpt variable import variables.tfvars -w my-workspace

# Auto-overwrite existing variables
hcpt variable import variables.tfvars -w my-workspace --overwrite

# Mark all imported variables as sensitive
hcpt variable import variables.tfvars -w my-workspace --sensitive
```

close #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
