### PR TITLE
Add `run logs` command to documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ hcpt
 ├── workspace show    # Show details of a specific workspace
 ├── run list          # Show run history for a workspace (filterable with --status)
 ├── run show          # Show run details (--watch to monitor until completion)
+├── run logs          # Show apply logs for a run (--error-only to filter errors)
 ├── variable list     # List variables in a workspace
 ├── variable set      # Create/update a variable (upsert)
 ├── variable delete   # Delete a variable

--- a/README.ja.md
+++ b/README.ja.md
@@ -140,6 +140,15 @@ hcpt run show --pr 42 --repo owner/repo --watch
 
 # GitHub PR から Run を表示（monorepo で複数ワークスペースがある場合）
 hcpt run show --pr 42 --repo owner/repo -w my-workspace
+
+# Apply ログを表示
+hcpt run logs run-abc123
+
+# エラー行のみ表示
+hcpt run logs run-abc123 --error-only
+
+# Workspace の最新 Run の Apply ログを表示
+hcpt run logs --org my-org -w my-workspace
 ```
 
 ### Variable

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ hcpt run show --pr 42 --repo owner/repo --watch
 
 # Show run from GitHub PR (specific workspace in monorepo)
 hcpt run show --pr 42 --repo owner/repo -w my-workspace
+
+# Show apply logs for a run
+hcpt run logs run-abc123
+
+# Show only error lines
+hcpt run logs run-abc123 --error-only
+
+# Show apply logs for the latest run in a workspace
+hcpt run logs --org my-org -w my-workspace
 ```
 
 ### Variables


### PR DESCRIPTION
## Summary

- Add `hcpt run logs` usage examples to `README.md` and `README.ja.md`
- Add `run logs` to the command structure in `CLAUDE.md`

## Related

- #45 (feature request)
- #46 (implementation PR)

## Test plan

- [x] Documentation only change, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)