### PR TITLE
Optimize .gitignore for Go project and macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# Build output
 hcpt
 dist/
+
+# Test files
 test-import.tfvars
+*.test
+coverage.out
+coverage.html
+
+# macOS
+.DS_Store
+
+# Claude Code
+.claude/


### PR DESCRIPTION
## Summary

- Add `.DS_Store` to ignore macOS metadata files
- Add `.claude/` to ignore Claude Code project settings
- Add `*.test`, `coverage.out`, `coverage.html` to ignore Go test artifacts

## Test plan

- [ ] Confirm `.DS_Store` is no longer tracked
- [ ] Confirm coverage files generated by `go test -coverprofile` are ignored