### PR TITLE
Group minor and patch updates in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,12 +18,14 @@
   "packageRules": [
     {
       "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "Go dependencies",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps"
     },
     {
       "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "GitHub Actions",
       "semanticCommitType": "ci",
       "semanticCommitScope": "actions"


### PR DESCRIPTION
## Summary

- Add `matchUpdateTypes` to `packageRules` to group minor, patch, pin, and digest updates together
- Major updates are excluded from grouping and will be created as individual PRs

## Changes

- `.github/renovate.json`: Add `matchUpdateTypes: ["minor", "patch", "pin", "digest"]` to Go modules and GitHub Actions rules