### PR TITLE
Refactor: split run/show.go into show.go, watch.go, and github.go

### DIFF
--- a/internal/cmd/run/github.go
+++ b/internal/cmd/run/github.go
@@ -1,0 +1,21 @@
+package run
+
+import (
+	"context"
+	"strings"
+
+	"github.com/nnstt1/hcpt/internal/client"
+)
+
+// resolveRunIDFromPR fetches the HCP Terraform run-id from a GitHub pull request's commit statuses.
+func resolveRunIDFromPR(ctx context.Context, repoFullName string, prNumber int, workspaceName string) (string, error) {
+	ghClient, err := client.NewGitHubClientWrapper()
+	if err != nil {
+		return "", err
+	}
+
+	parts := strings.Split(repoFullName, "/")
+	owner, repo := parts[0], parts[1]
+
+	return ghClient.GetRunIDFromPR(ctx, owner, repo, prNumber, workspaceName)
+}

--- a/internal/cmd/run/show.go
+++ b/internal/cmd/run/show.go
@@ -118,17 +118,8 @@ func newCmdRunShowWith(clientFn runShowClientFactory) *cobra.Command {
 
 			// If --pr is specified, get run-id from GitHub
 			if prNumber > 0 {
-				ghClient, err := client.NewGitHubClientWrapper()
-				if err != nil {
-					return err
-				}
-
-				// Parse owner/repo
-				parts := strings.Split(repoFullName, "/")
-				owner, repo := parts[0], parts[1]
-
 				ctx := context.Background()
-				runID, err = ghClient.GetRunIDFromPR(ctx, owner, repo, prNumber, workspaceName)
+				runID, err = resolveRunIDFromPR(ctx, repoFullName, prNumber, workspaceName)
 				if err != nil {
 					return err
 				}
@@ -496,88 +487,4 @@ func displayPlanJSON(ctx context.Context, svc runShowService, r *tfe.Run) error 
 	_, _ = fmt.Fprintln(os.Stdout, "---")
 	_, _ = fmt.Fprintln(os.Stdout, string(planJSONBytes))
 	return nil
-}
-
-// watchRun polls the run status until it reaches a terminal state.
-func watchRun(ctx context.Context, svc runShowService, runID string, initialRun *tfe.Run, pollInterval time.Duration) error {
-	// In watch mode, skip fetching resource changes (inefficient to fetch on every poll)
-	var resourceChanges []resourceChange
-
-	// If already in terminal status, display only the initial output and exit
-	if isTerminalStatus(initialRun.Status) {
-		// Fetch resource changes only when terminal status is reached
-		if initialRun.Plan != nil && initialRun.HasChanges {
-			planJSONBytes, err := svc.ReadPlanJSONOutput(ctx, initialRun.Plan.ID)
-			if err == nil {
-				resourceChanges, _ = extractResourceChanges(planJSONBytes)
-			}
-		}
-		return displayRun(initialRun, resourceChanges)
-	}
-
-	// In non-JSON mode, display initial output and separator
-	if !viper.GetBool("json") {
-		if err := displayRun(initialRun, nil); err != nil {
-			return err
-		}
-		_, _ = fmt.Fprintln(os.Stdout, "---")
-	}
-
-	ticker := time.NewTicker(pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-			r, err := svc.ReadRun(ctx, runID)
-			if err != nil {
-				// Possibly a transient error; print warning and continue
-				fmt.Fprintf(os.Stderr, "Warning: failed to read run: %v\n", err)
-				continue
-			}
-
-			// Output status on each poll
-			if !viper.GetBool("json") {
-				_, _ = fmt.Fprintln(os.Stdout, formatStatusUpdate(time.Now(), r.Status))
-			}
-
-			// When terminal status is reached, display final result and exit
-			if isTerminalStatus(r.Status) {
-				// Fetch resource changes when terminal status is reached
-				var finalChanges []resourceChange
-				if r.Plan != nil && r.HasChanges {
-					planJSONBytes, err := svc.ReadPlanJSONOutput(ctx, r.Plan.ID)
-					if err == nil {
-						finalChanges, _ = extractResourceChanges(planJSONBytes)
-					}
-				}
-				if !viper.GetBool("json") {
-					_, _ = fmt.Fprintln(os.Stdout, "---")
-				}
-				return displayRun(r, finalChanges)
-			}
-		}
-	}
-}
-
-// isTerminalStatus returns true if the status is a terminal state.
-func isTerminalStatus(status tfe.RunStatus) bool {
-	switch status {
-	case tfe.RunApplied,
-		tfe.RunErrored,
-		tfe.RunCanceled,
-		tfe.RunDiscarded,
-		tfe.RunPlannedAndFinished,
-		tfe.RunPlannedAndSaved:
-		return true
-	default:
-		return false
-	}
-}
-
-// formatStatusUpdate formats a status update line with timestamp.
-func formatStatusUpdate(timestamp time.Time, status tfe.RunStatus) string {
-	return fmt.Sprintf("%s  Status: %s", timestamp.Format("2006-01-02 15:04:05"), status)
 }

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -1,0 +1,95 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/spf13/viper"
+)
+
+// watchRun polls the run status until it reaches a terminal state.
+func watchRun(ctx context.Context, svc runShowService, runID string, initialRun *tfe.Run, pollInterval time.Duration) error {
+	// In watch mode, skip fetching resource changes (inefficient to fetch on every poll)
+	var resourceChanges []resourceChange
+
+	// If already in terminal status, display only the initial output and exit
+	if isTerminalStatus(initialRun.Status) {
+		// Fetch resource changes only when terminal status is reached
+		if initialRun.Plan != nil && initialRun.HasChanges {
+			planJSONBytes, err := svc.ReadPlanJSONOutput(ctx, initialRun.Plan.ID)
+			if err == nil {
+				resourceChanges, _ = extractResourceChanges(planJSONBytes)
+			}
+		}
+		return displayRun(initialRun, resourceChanges)
+	}
+
+	// In non-JSON mode, display initial output and separator
+	if !viper.GetBool("json") {
+		if err := displayRun(initialRun, nil); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintln(os.Stdout, "---")
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			r, err := svc.ReadRun(ctx, runID)
+			if err != nil {
+				// Possibly a transient error; print warning and continue
+				fmt.Fprintf(os.Stderr, "Warning: failed to read run: %v\n", err)
+				continue
+			}
+
+			// Output status on each poll
+			if !viper.GetBool("json") {
+				_, _ = fmt.Fprintln(os.Stdout, formatStatusUpdate(time.Now(), r.Status))
+			}
+
+			// When terminal status is reached, display final result and exit
+			if isTerminalStatus(r.Status) {
+				// Fetch resource changes when terminal status is reached
+				var finalChanges []resourceChange
+				if r.Plan != nil && r.HasChanges {
+					planJSONBytes, err := svc.ReadPlanJSONOutput(ctx, r.Plan.ID)
+					if err == nil {
+						finalChanges, _ = extractResourceChanges(planJSONBytes)
+					}
+				}
+				if !viper.GetBool("json") {
+					_, _ = fmt.Fprintln(os.Stdout, "---")
+				}
+				return displayRun(r, finalChanges)
+			}
+		}
+	}
+}
+
+// isTerminalStatus returns true if the status is a terminal state.
+func isTerminalStatus(status tfe.RunStatus) bool {
+	switch status {
+	case tfe.RunApplied,
+		tfe.RunErrored,
+		tfe.RunCanceled,
+		tfe.RunDiscarded,
+		tfe.RunPlannedAndFinished,
+		tfe.RunPlannedAndSaved:
+		return true
+	default:
+		return false
+	}
+}
+
+// formatStatusUpdate formats a status update line with timestamp.
+func formatStatusUpdate(timestamp time.Time, status tfe.RunStatus) string {
+	return fmt.Sprintf("%s  Status: %s", timestamp.Format("2006-01-02 15:04:05"), status)
+}


### PR DESCRIPTION
## Summary

- Extract watch mode logic into `watch.go` (`watchRun`, `isTerminalStatus`, `formatStatusUpdate`)
- Extract GitHub PR integration into `github.go` (`resolveRunIDFromPR`)
- `show.go` retains core command definition, argument validation, and run/plan display

## Changes

| File | Lines | Responsibility |
|------|-------|----------------|
| `show.go` | 490 (was 583) | Core show command, validation, run/plan display |
| `watch.go` | 95 | Watch mode polling loop and terminal status helpers |
| `github.go` | 21 | PR-to-run-id resolution via GitHub commit statuses |

## Test plan

- [x] All existing tests pass (`go test ./internal/cmd/run/...`)
- [x] `go vet ./...` passes
- [x] `golangci-lint run` passes (0 issues)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)