### PR TITLE
Add project show command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ hcpt
 ├── org list          # List organizations
 ├── org show          # Show organization details, contract plan, and entitlements
 ├── project list      # List projects within an organization
+├── project show      # Show project details
 ├── drift list        # List drifted workspaces (--all for all results)
 ├── drift show        # Show drift detection details for a specific workspace
 ├── workspace list    # List workspaces within an organization

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ hcpt org show --org my-org
 ```bash
 # List projects in an organization
 hcpt project list --org my-org
+
+# Show project details
+hcpt project show my-project --org my-org
 ```
 
 ### Workspaces

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -12,6 +12,7 @@ func NewCmdProject() *cobra.Command {
 	}
 
 	cmd.AddCommand(newCmdProjectList())
+	cmd.AddCommand(newCmdProjectShow())
 
 	return cmd
 }

--- a/internal/cmd/project/show.go
+++ b/internal/cmd/project/show.go
@@ -1,0 +1,154 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/nnstt1/hcpt/internal/client"
+	"github.com/nnstt1/hcpt/internal/output"
+)
+
+type projectShowService interface {
+	client.ProjectService
+	client.WorkspaceService
+}
+
+type projectShowJSON struct {
+	Name                 string              `json:"name"`
+	ID                   string              `json:"id"`
+	Description          string              `json:"description"`
+	DefaultExecutionMode string              `json:"default_execution_mode"`
+	Workspaces           []showWorkspaceJSON `json:"workspaces"`
+}
+
+type showWorkspaceJSON struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
+
+type projectShowClientFactory func() (projectShowService, error)
+
+func defaultProjectShowClientFactory() (projectShowService, error) {
+	return client.NewClientWrapper()
+}
+
+func newCmdProjectShow() *cobra.Command {
+	return newCmdProjectShowWith(defaultProjectShowClientFactory)
+}
+
+func newCmdProjectShowWith(clientFn projectShowClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "show <name>",
+		Short:        "Show project details",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org := viper.GetString("org")
+			if org == "" {
+				return errOrgRequired
+			}
+
+			svc, err := clientFn()
+			if err != nil {
+				return err
+			}
+			return runProjectShow(svc, org, args[0])
+		},
+	}
+	return cmd
+}
+
+func runProjectShow(svc projectShowService, org, name string) error {
+	ctx := context.Background()
+
+	// Find project by name
+	projList, err := svc.ListProjects(ctx, org, &tfe.ProjectListOptions{
+		Name: name,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list projects: %w", err)
+	}
+
+	var found *tfe.Project
+	for _, p := range projList.Items {
+		if p.Name == name {
+			found = p
+			break
+		}
+	}
+	if found == nil {
+		return fmt.Errorf("project %q not found in organization %q", name, org)
+	}
+
+	// List workspaces in this project
+	workspaces, err := listProjectWorkspaces(ctx, svc, org, found.ID)
+	if err != nil {
+		return fmt.Errorf("failed to list workspaces: %w", err)
+	}
+
+	if viper.GetBool("json") {
+		wsItems := make([]showWorkspaceJSON, 0, len(workspaces))
+		for _, ws := range workspaces {
+			wsItems = append(wsItems, showWorkspaceJSON{
+				Name: ws.Name,
+				ID:   ws.ID,
+			})
+		}
+		return output.PrintJSON(os.Stdout, projectShowJSON{
+			Name:                 found.Name,
+			ID:                   found.ID,
+			Description:          found.Description,
+			DefaultExecutionMode: found.DefaultExecutionMode,
+			Workspaces:           wsItems,
+		})
+	}
+
+	pairs := []output.KeyValue{
+		{Key: "Name", Value: found.Name},
+		{Key: "ID", Value: found.ID},
+		{Key: "Description", Value: found.Description},
+		{Key: "Default Execution Mode", Value: found.DefaultExecutionMode},
+		{Key: "Workspaces", Value: strconv.Itoa(len(workspaces))},
+	}
+
+	output.PrintKeyValue(os.Stdout, pairs)
+
+	if len(workspaces) > 0 {
+		fmt.Fprintln(os.Stderr)
+		headers := []string{"NAME", "ID"}
+		rows := make([][]string, 0, len(workspaces))
+		for _, ws := range workspaces {
+			rows = append(rows, []string{ws.Name, ws.ID})
+		}
+		output.Print(os.Stdout, headers, rows)
+	}
+
+	return nil
+}
+
+func listProjectWorkspaces(ctx context.Context, svc client.WorkspaceService, org, projectID string) ([]*tfe.Workspace, error) {
+	opts := &tfe.WorkspaceListOptions{
+		ListOptions: tfe.ListOptions{PageSize: 100},
+		ProjectID:   projectID,
+	}
+
+	var all []*tfe.Workspace
+	for {
+		wsList, err := svc.ListWorkspaces(ctx, org, opts)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, wsList.Items...)
+		if wsList.Pagination == nil || wsList.NextPage == 0 {
+			break
+		}
+		opts.PageNumber = wsList.NextPage
+	}
+	return all, nil
+}

--- a/internal/cmd/project/show_test.go
+++ b/internal/cmd/project/show_test.go
@@ -1,0 +1,267 @@
+package project
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/spf13/viper"
+)
+
+type mockProjectShowService struct {
+	projects   []*tfe.Project
+	workspaces []*tfe.Workspace
+	projErr    error
+	wsErr      error
+	listFn     func(opts *tfe.ProjectListOptions) (*tfe.ProjectList, error)
+}
+
+func (m *mockProjectShowService) ListProjects(_ context.Context, _ string, opts *tfe.ProjectListOptions) (*tfe.ProjectList, error) {
+	if m.listFn != nil {
+		return m.listFn(opts)
+	}
+	if m.projErr != nil {
+		return nil, m.projErr
+	}
+	return &tfe.ProjectList{
+		Items: m.projects,
+	}, nil
+}
+
+func (m *mockProjectShowService) ListWorkspaces(_ context.Context, _ string, _ *tfe.WorkspaceListOptions) (*tfe.WorkspaceList, error) {
+	if m.wsErr != nil {
+		return nil, m.wsErr
+	}
+	return &tfe.WorkspaceList{
+		Items: m.workspaces,
+	}, nil
+}
+
+func (m *mockProjectShowService) ReadWorkspace(_ context.Context, _ string, _ string) (*tfe.Workspace, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestProjectShow_Table(t *testing.T) {
+	viper.Reset()
+	viper.Set("json", false)
+	viper.Set("org", "test-org")
+
+	mock := &mockProjectShowService{
+		projects: []*tfe.Project{
+			{
+				Name:                 "my-project",
+				ID:                   "prj-abc123",
+				Description:          "My test project",
+				DefaultExecutionMode: "remote",
+			},
+		},
+		workspaces: []*tfe.Workspace{
+			{Name: "ws-prod", ID: "ws-111"},
+			{Name: "ws-dev", ID: "ws-222"},
+		},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	oldStderr := os.Stderr
+	_, wErr, _ := os.Pipe()
+	os.Stderr = wErr
+
+	err := runProjectShow(mock, "test-org", "my-project")
+
+	_ = w.Close()
+	_ = wErr.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	for _, want := range []string{"Name", "my-project", "ID", "prj-abc123", "Default Execution Mode", "remote", "Workspaces", "2", "ws-prod", "ws-dev"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestProjectShow_JSON(t *testing.T) {
+	viper.Reset()
+	viper.Set("json", true)
+	viper.Set("org", "test-org")
+
+	mock := &mockProjectShowService{
+		projects: []*tfe.Project{
+			{
+				Name:                 "my-project",
+				ID:                   "prj-abc123",
+				Description:          "My test project",
+				DefaultExecutionMode: "remote",
+			},
+		},
+		workspaces: []*tfe.Workspace{
+			{Name: "ws-prod", ID: "ws-111"},
+		},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runProjectShow(mock, "test-org", "my-project")
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	for _, want := range []string{`"name": "my-project"`, `"id": "prj-abc123"`, `"default_execution_mode": "remote"`, `"workspaces"`, `"name": "ws-prod"`, `"id": "ws-111"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in JSON output, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestProjectShow_NoWorkspaces(t *testing.T) {
+	viper.Reset()
+	viper.Set("json", false)
+	viper.Set("org", "test-org")
+
+	mock := &mockProjectShowService{
+		projects: []*tfe.Project{
+			{
+				Name: "empty-project",
+				ID:   "prj-empty",
+			},
+		},
+		workspaces: []*tfe.Workspace{},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runProjectShow(mock, "test-org", "empty-project")
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := buf.String()
+
+	if !strings.Contains(got, "Workspaces") {
+		t.Errorf("expected 'Workspaces' in output, got:\n%s", got)
+	}
+	if strings.Contains(got, "NAME") {
+		t.Errorf("expected no workspace table header when no workspaces, got:\n%s", got)
+	}
+}
+
+func TestProjectShow_NotFound(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	mock := &mockProjectShowService{
+		projects: []*tfe.Project{},
+	}
+
+	err := runProjectShow(mock, "test-org", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestProjectShow_NoOrg(t *testing.T) {
+	viper.Reset()
+
+	cmd := newCmdProjectShowWith(func() (projectShowService, error) {
+		return &mockProjectShowService{}, nil
+	})
+	cmd.SetArgs([]string{"my-project"})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "organization is required") {
+		t.Errorf("expected 'organization is required' error, got: %v", err)
+	}
+}
+
+func TestProjectShow_WorkspaceListError(t *testing.T) {
+	viper.Reset()
+	viper.Set("json", false)
+	viper.Set("org", "test-org")
+
+	mock := &mockProjectShowService{
+		projects: []*tfe.Project{
+			{
+				Name: "my-project",
+				ID:   "prj-abc123",
+			},
+		},
+		wsErr: fmt.Errorf("workspace api error"),
+	}
+
+	err := runProjectShow(mock, "test-org", "my-project")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "workspace api error") {
+		t.Errorf("expected 'workspace api error' error, got: %v", err)
+	}
+}
+
+func TestProjectShow_ClientError(t *testing.T) {
+	viper.Reset()
+	viper.Set("org", "test-org")
+
+	cmd := newCmdProjectShowWith(func() (projectShowService, error) {
+		return nil, fmt.Errorf("token missing")
+	})
+	cmd.SetArgs([]string{"my-project"})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "token missing") {
+		t.Errorf("expected 'token missing' error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `project show <name>` subcommand to display project details and its workspaces
- Table output shows project info (Name, ID, Description, Default Execution Mode) followed by a workspace list
- JSON output includes a `workspaces` array with name and ID for each workspace
- Uses `ProjectID` filter on `WorkspaceListOptions` to fetch only workspaces belonging to the project

Closes #1

## Test plan

- [x] `go test ./internal/cmd/project/ -run TestProjectShow` (7 tests pass)
- [x] `go vet ./...`
- [x] `gofmt -d .`
- [x] Manual test with real HCP Terraform org

🤖 Generated with [Claude Code](https://claude.com/claude-code)