### PR TITLE
Fix drift show --json unmarshal error for bool sensitive fields

### DIFF
--- a/internal/client/assessment_test.go
+++ b/internal/client/assessment_test.go
@@ -472,3 +472,84 @@ func TestParseAssessmentJSONOutput_FiltersNoOp(t *testing.T) {
 		t.Error("expected Before to be non-nil")
 	}
 }
+
+func TestParseAssessmentJSONOutput_BoolSensitive(t *testing.T) {
+	// before_sensitive/after_sensitive can be bool (false) when no sensitive attributes exist
+	jsonBody := []byte(`{
+		"resource_changes": [
+			{
+				"address": "aws_instance.test",
+				"type": "aws_instance",
+				"name": "test",
+				"change": {
+					"actions": ["update"],
+					"before": {"ami": "ami-old"},
+					"after": {"ami": "ami-new"},
+					"after_unknown": {},
+					"before_sensitive": false,
+					"after_sensitive": false
+				}
+			}
+		]
+	}`)
+
+	resources, err := parseAssessmentJSONOutput(jsonBody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	r := resources[0]
+	if r.Address != "aws_instance.test" {
+		t.Errorf("expected address 'aws_instance.test', got %q", r.Address)
+	}
+	// BeforeSensitive/AfterSensitive should be bool false, not nil
+	if r.BeforeSensitive != false {
+		t.Errorf("expected BeforeSensitive=false, got %v", r.BeforeSensitive)
+	}
+	if r.AfterSensitive != false {
+		t.Errorf("expected AfterSensitive=false, got %v", r.AfterSensitive)
+	}
+}
+
+func TestParseAssessmentJSONOutput_MixedSensitive(t *testing.T) {
+	// before_sensitive is a map, after_sensitive is bool false
+	jsonBody := []byte(`{
+		"resource_changes": [
+			{
+				"address": "aws_instance.test",
+				"type": "aws_instance",
+				"name": "test",
+				"change": {
+					"actions": ["update"],
+					"before": {"ami": "ami-old", "password": "secret"},
+					"after": {"ami": "ami-new", "password": "newsecret"},
+					"after_unknown": {},
+					"before_sensitive": {"password": true},
+					"after_sensitive": false
+				}
+			}
+		]
+	}`)
+
+	resources, err := parseAssessmentJSONOutput(jsonBody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	r := resources[0]
+
+	bsMap, ok := r.BeforeSensitive.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected BeforeSensitive to be map, got %T", r.BeforeSensitive)
+	}
+	if bsMap["password"] != true {
+		t.Errorf("expected BeforeSensitive['password']=true, got %v", bsMap["password"])
+	}
+	if r.AfterSensitive != false {
+		t.Errorf("expected AfterSensitive=false, got %v", r.AfterSensitive)
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -77,8 +77,8 @@ type DriftedResource struct {
 	Before          map[string]interface{}
 	After           map[string]interface{}
 	AfterUnknown    map[string]interface{}
-	BeforeSensitive map[string]interface{}
-	AfterSensitive  map[string]interface{}
+	BeforeSensitive interface{}
+	AfterSensitive  interface{}
 }
 
 // AssessmentService provides operations to read workspace assessment results.
@@ -494,8 +494,8 @@ type resourceChange struct {
 		Before          map[string]interface{} `json:"before"`
 		After           map[string]interface{} `json:"after"`
 		AfterUnknown    map[string]interface{} `json:"after_unknown"`
-		BeforeSensitive map[string]interface{} `json:"before_sensitive"`
-		AfterSensitive  map[string]interface{} `json:"after_sensitive"`
+		BeforeSensitive interface{}            `json:"before_sensitive"`
+		AfterSensitive  interface{}            `json:"after_sensitive"`
 	} `json:"change"`
 }
 

--- a/internal/cmd/drift/show.go
+++ b/internal/cmd/drift/show.go
@@ -248,7 +248,7 @@ func isKnownAfterApply(key string, flatAfterUnknown map[string]interface{}) bool
 // computeDiffs compares before and after maps and returns sorted attribute diffs.
 // afterUnknown marks attributes whose after value will be known only after apply.
 // beforeSensitive/afterSensitive mark attributes whose values must not be displayed.
-func computeDiffs(before, after, afterUnknown, beforeSensitive, afterSensitive map[string]interface{}) []attributeDiff { //nolint:gocyclo // complex by nature, refactor tracked in separate issue
+func computeDiffs(before, after, afterUnknown map[string]interface{}, beforeSensitive, afterSensitive interface{}) []attributeDiff { //nolint:gocyclo // complex by nature, refactor tracked in separate issue
 	flatBefore := make(map[string]interface{})
 	flatAfter := make(map[string]interface{})
 	flatAfterUnknown := make(map[string]interface{})
@@ -264,11 +264,11 @@ func computeDiffs(before, after, afterUnknown, beforeSensitive, afterSensitive m
 	if afterUnknown != nil {
 		flattenMap("", afterUnknown, flatAfterUnknown)
 	}
-	if beforeSensitive != nil {
-		flattenMap("", beforeSensitive, flatBeforeSensitive)
+	if m, ok := beforeSensitive.(map[string]interface{}); ok {
+		flattenMap("", m, flatBeforeSensitive)
 	}
-	if afterSensitive != nil {
-		flattenMap("", afterSensitive, flatAfterSensitive)
+	if m, ok := afterSensitive.(map[string]interface{}); ok {
+		flattenMap("", m, flatAfterSensitive)
 	}
 
 	// Collect all keys from before and after

--- a/internal/cmd/drift/show_test.go
+++ b/internal/cmd/drift/show_test.go
@@ -878,3 +878,79 @@ func TestComputeDiffs_SensitiveValue_ParentKey(t *testing.T) {
 		t.Error("expected Sensitive=true")
 	}
 }
+
+// TestComputeDiffs_BoolSensitive verifies that computeDiffs handles bool values
+// for beforeSensitive/afterSensitive (returned by HCP Terraform when no sensitive attributes exist).
+func TestComputeDiffs_BoolSensitive(t *testing.T) {
+	before := map[string]interface{}{
+		"name": "old",
+	}
+	after := map[string]interface{}{
+		"name": "new",
+	}
+
+	// bool false means no sensitive attributes
+	diffs := computeDiffs(before, after, nil, false, false)
+
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d: %+v", len(diffs), diffs)
+	}
+	d := diffs[0]
+	if d.Key != "name" {
+		t.Errorf("expected key 'name', got %q", d.Key)
+	}
+	if d.Before != `"old"` {
+		t.Errorf("expected Before '\"old\"', got %q", d.Before)
+	}
+	if d.After != `"new"` {
+		t.Errorf("expected After '\"new\"', got %q", d.After)
+	}
+	if d.Sensitive {
+		t.Error("expected Sensitive=false")
+	}
+}
+
+// TestComputeDiffs_MixedSensitive verifies that computeDiffs handles the case where
+// beforeSensitive is a map but afterSensitive is a bool (or vice versa).
+func TestComputeDiffs_MixedSensitive(t *testing.T) {
+	before := map[string]interface{}{
+		"password": "secret",
+		"name":     "old",
+	}
+	after := map[string]interface{}{
+		"password": "newsecret",
+		"name":     "new",
+	}
+
+	// beforeSensitive is a map, afterSensitive is bool false
+	beforeSensitive := map[string]interface{}{
+		"password": true,
+	}
+
+	diffs := computeDiffs(before, after, nil, beforeSensitive, false)
+
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs, got %d: %+v", len(diffs), diffs)
+	}
+
+	// Sort by key for predictable order
+	diffMap := make(map[string]attributeDiff)
+	for _, d := range diffs {
+		diffMap[d.Key] = d
+	}
+
+	// "name" should not be sensitive
+	nameD := diffMap["name"]
+	if nameD.Sensitive {
+		t.Error("expected name Sensitive=false")
+	}
+
+	// "password" should be sensitive (marked in beforeSensitive)
+	pwD := diffMap["password"]
+	if !pwD.Sensitive {
+		t.Error("expected password Sensitive=true")
+	}
+	if pwD.Before != "(sensitive value)" {
+		t.Errorf("expected Before '(sensitive value)', got %q", pwD.Before)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `json.Unmarshal` error when HCP Terraform assessment API returns `false` (bool) for `before_sensitive`/`after_sensitive` fields instead of a map
- Change `BeforeSensitive`/`AfterSensitive` field types from `map[string]interface{}` to `interface{}` and use type assertion in `computeDiffs`
- Add tests for bool-only and mixed (map + bool) sensitive field patterns

Closes #80

## Test plan

- [x] `go build` succeeds
- [x] `go test ./internal/...` all pass
- [x] `go vet ./...` clean
- [x] `gofmt -d` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)