### PR TITLE
Pin GitHub Actions to commit SHAs using pinact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -25,13 +25,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,19 +12,19 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in workflow files to full commit SHAs using [pinact](https://github.com/suzuki-shunsuke/pinact) to mitigate supply chain attacks

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v6` | `@de0fac2...` (v6.0.2) |
| `actions/setup-go` | `@v6` | `@4a36011...` (v6.4.0) |
| `golangci/golangci-lint-action` | `@v9` | `@1e7e51e...` (v9.2.0) |
| `anchore/sbom-action/download-syft` | `@v0` | `@e22c389...` (v0.24.0) |
| `goreleaser/goreleaser-action` | `@v7` | `@ec59f47...` (v7.0.0) |

Renovate is already configured to handle hash-pinned actions (`digest` update type), so no config changes are needed.

Closes #84

## Test plan

- [ ] CI workflow (test + lint) passes
- [ ] `pinact run --check` reports no unpinned actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)