### PR TITLE
Add security checks workflow with pinact and zizmor

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,35 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
+        with:
+          skip_push: "true"
+          verify: "true"
+
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Summary

- Add `.github/workflows/security.yml` with two security check jobs:
  - **pinact**: Verifies all GitHub Actions are pinned to commit SHAs
  - **zizmor**: Static security analysis of workflow files (SARIF upload to Code Scanning)

## Details

- pinact runs in verify-only mode (`skip_push: true`, `verify: true`) — fails CI if any action is not hash-pinned
- zizmor uses GitHub Advanced Security (free for public repos) to upload findings to Code Scanning
- The workflow itself follows security best practices: hash-pinned actions, minimal permissions, `persist-credentials: false`

Closes #85

## Test plan

- [ ] `pinact` job passes (all actions are hash-pinned)
- [ ] `zizmor` job passes (no security issues in workflows)
- [ ] Existing CI jobs (test, lint) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)