### PR TITLE
Unify go-github to v85 and remove unused v84

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ go 1.25.6
 
 require (
 	github.com/Songmu/skillsmith v0.0.2
-	github.com/google/go-github/v83 v83.0.0
-	github.com/google/go-github/v84 v84.0.0
+	github.com/google/go-github/v85 v85.0.0
 	github.com/hashicorp/go-tfe v1.101.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -22,9 +22,8 @@ github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7Lk
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v83 v83.0.0 h1:Ydy4gAfqxrnFUwXAuKl/OMhhGa0KtMtnJ3EozIIuHT0=
-github.com/google/go-github/v83 v83.0.0/go.mod h1:gbqarhK37mpSu8Xy7sz21ITtznvzouyHSAajSaYCHe8=
-github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXukJBn73xsiYrRRQ=
+github.com/google/go-github/v85 v85.0.0 h1:1+TLFX/akTFXK7o9Z9uAloQGufOn4ySa5DItUM1VWT4=
+github.com/google/go-github/v85 v85.0.0/go.mod h1:jYkBnqN+SzR2A2fGKYfbt6DEEQAyxeK0Q2XpPV9ZFsU=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=

--- a/internal/client/client_http_test.go
+++ b/internal/client/client_http_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v83/github"
+	"github.com/google/go-github/v85/github"
 	"github.com/spf13/viper"
 )
 

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/go-github/v83/github"
+	"github.com/google/go-github/v85/github"
 	"github.com/spf13/viper"
 )
 


### PR DESCRIPTION
## Summary

- The codebase imports `github.com/google/go-github/v83` but `go.mod` also pinned `v84` as a phantom dependency that no source file imports.
- Because Go modules treat `/vN` suffixes as separate modules, Renovate cannot rewrite import paths automatically — it just bumps `go.mod`, which is how v84 ended up there in #76. As a result, Renovate now opens duplicate PRs (#89 for v83→v85, #90 for v84→v85), and merging either alone would not fix the duplication.
- This PR consolidates everything to a single `v85`: rewrites the imports in `internal/client/github.go` and `internal/client/client_http_test.go`, drops both `v83` and `v84` from `go.mod`, and runs `go mod tidy`.
- The breaking changes between v83 and v85 (`OrgRole` / `MarkThreadDone` / `IssuesService.List`) are not used in this codebase, so the migration is import-path only.

After this lands, #89 and #90 should be closed since they are no longer relevant.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -d .`
- [x] `go test ./...`